### PR TITLE
Add auto scaling config for memory and cpu.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/norwoodj/helm-docs
-    rev: v1.11.0
+    rev: v1.14.2
     hooks:
       - id: helm-docs
         args:
@@ -9,7 +9,7 @@ repos:
           - --sort-values-order=file
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -51,6 +51,8 @@ helm install app helm-charts/app
 | secretVolume | object | `{}` | Secret values that will be available as files in `/secrets` inside the container. Formatted as `file.name: <base64 encoded file>` |
 | deployment.replicas | int | `1` | The minimum number of replicas of the application |
 | deployment.maxReplicas | int | `.Values.deployment.replicas | The maximum number of replicas of the application |
+| deployment.averageCpuUtilization | int | `95` | The target average CPU utilization percentage for the HorizontalPodAutoscaler |
+| deployment.averageMemoryUtilization | int | `75` | The target average Memory utilization percentage for the HorizontalPodAutoscaler |
 | ports.app-port.port | int | `8080` | The port the application is listening on |
 | ports.app-port.protocol | string | `"TCP"` | The protocol the application uses. This should alost always be TCP |
 | ports.app-port.expose | bool | `true` | Whether the port should be accessible to the cluster and outside world |

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -52,7 +52,7 @@ helm install app helm-charts/app
 | deployment.replicas | int | `1` | The minimum number of replicas of the application |
 | deployment.maxReplicas | int | `.Values.deployment.replicas | The maximum number of replicas of the application |
 | deployment.averageCpuUtilization | int | `80` | The target average CPU utilization percentage for the HorizontalPodAutoscaler |
-| deployment.averageMemoryUtilization | int | `75` | The target average Memory utilization percentage for the HorizontalPodAutoscaler |
+| deployment.averageMemoryUtilization | int | `disabled` | The target average Memory utilization percentage for the HorizontalPodAutoscaler |
 | ports.app-port.port | int | `8080` | The port the application is listening on |
 | ports.app-port.protocol | string | `"TCP"` | The protocol the application uses. This should alost always be TCP |
 | ports.app-port.expose | bool | `true` | Whether the port should be accessible to the cluster and outside world |

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -51,7 +51,7 @@ helm install app helm-charts/app
 | secretVolume | object | `{}` | Secret values that will be available as files in `/secrets` inside the container. Formatted as `file.name: <base64 encoded file>` |
 | deployment.replicas | int | `1` | The minimum number of replicas of the application |
 | deployment.maxReplicas | int | `.Values.deployment.replicas | The maximum number of replicas of the application |
-| deployment.averageCpuUtilization | int | `95` | The target average CPU utilization percentage for the HorizontalPodAutoscaler |
+| deployment.averageCpuUtilization | int | `80` | The target average CPU utilization percentage for the HorizontalPodAutoscaler |
 | deployment.averageMemoryUtilization | int | `75` | The target average Memory utilization percentage for the HorizontalPodAutoscaler |
 | ports.app-port.port | int | `8080` | The port the application is listening on |
 | ports.app-port.protocol | string | `"TCP"` | The protocol the application uses. This should alost always be TCP |

--- a/charts/app/templates/kubernetes/hpa.yaml
+++ b/charts/app/templates/kubernetes/hpa.yaml
@@ -17,4 +17,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.deployment.averageUtilization }}
+        averageUtilization: {{ .Values.deployment.averageCpuUtilization }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.deployment.averageMemoryUtilization }}

--- a/charts/app/templates/kubernetes/hpa.yaml
+++ b/charts/app/templates/kubernetes/hpa.yaml
@@ -18,9 +18,11 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.deployment.averageCpuUtilization }}
+  {{- if .Values.deployment.averageMemoryUtilization }}
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
         averageUtilization: {{ .Values.deployment.averageMemoryUtilization }}
+  {{- end }}

--- a/charts/app/templates/kubernetes/hpa.yaml
+++ b/charts/app/templates/kubernetes/hpa.yaml
@@ -17,4 +17,4 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 95
+        averageUtilization: {{ .Values.deployment.averageUtilization }}

--- a/charts/app/tests/kubernetes_hpa_test.yaml
+++ b/charts/app/tests/kubernetes_hpa_test.yaml
@@ -45,49 +45,45 @@ tests:
           path: spec.maxReplicas
           value: 10
 
-  - it: Should scale at 96% CPU utilization by default
+  - it: Should scale at 95% CPU utilization by default
     set:
       template: kubernetes/hpa.yaml
     asserts:
-      - equal:
-          path: spec.metrics[0].type
-          value: Resource
-      - equal:
-          path: spec.metrics[0].resource.name
-          value: cpu
-      - equal:
-          path: spec.metrics[0].resource.target.type
-          value: Utilization
-      - equal:
-          path: spec.metrics[0].resource.target.averageUtilization
-          value: 95
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 95
 
   - it: Should scale at configured CPU utilization
     set:
       deployment:
-        averageCpuUtilization: 10
+        averageCpuUtilization: 80
     template: kubernetes/hpa.yaml
     asserts:
-      - equal:
-          path: spec.metrics[0].resource.target.averageUtilization
-          value: 10
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 80
 
-  - it: Should scale at 75% Memory utilization by default
+  - it: Should not have memory utilization metric by default
     set:
       template: kubernetes/hpa.yaml
     asserts:
-      - equal:
-          path: spec.metrics[1].type
-          value: Resource
-      - equal:
-          path: spec.metrics[1].resource.name
-          value: memory
-      - equal:
-          path: spec.metrics[1].resource.target.type
-          value: Utilization
-      - equal:
-          path: spec.metrics[1].resource.target.averageUtilization
-          value: 75
+      - notContains:
+          path: spec.metrics
+          content:
+            resource:
+              name: memory
 
   - it: Should scale at configured Memory utilization
     set:
@@ -95,6 +91,12 @@ tests:
         averageMemoryUtilization: 50
     template: kubernetes/hpa.yaml
     asserts:
-      - equal:
-          path: spec.metrics[1].resource.target.averageUtilization
-          value: 50
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 50

--- a/charts/app/tests/kubernetes_hpa_test.yaml
+++ b/charts/app/tests/kubernetes_hpa_test.yaml
@@ -60,17 +60,17 @@ tests:
           value: Utilization
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
-          value: 95
+          value: 80
 
   - it: Should scale at configured CPU utilization
     set:
       deployment:
-        averageCpuUtilization: 80
+        averageCpuUtilization: 10
     template: kubernetes/hpa.yaml
     asserts:
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
-          value: 80
+          value: 10
 
   - it: Should scale at 75% Memory utilization by default
     set:

--- a/charts/app/tests/kubernetes_hpa_test.yaml
+++ b/charts/app/tests/kubernetes_hpa_test.yaml
@@ -61,3 +61,13 @@ tests:
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
           value: 95
+
+  - it: Should scale at configured CPU utilization
+    set:
+      deployment:
+        averageUtilization: 80
+    template: kubernetes/hpa.yaml
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 80

--- a/charts/app/tests/kubernetes_hpa_test.yaml
+++ b/charts/app/tests/kubernetes_hpa_test.yaml
@@ -65,9 +65,36 @@ tests:
   - it: Should scale at configured CPU utilization
     set:
       deployment:
-        averageUtilization: 80
+        averageCpuUtilization: 80
     template: kubernetes/hpa.yaml
     asserts:
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
           value: 80
+
+  - it: Should scale at 75% Memory utilization by default
+    set:
+      template: kubernetes/hpa.yaml
+    asserts:
+      - equal:
+          path: spec.metrics[1].type
+          value: Resource
+      - equal:
+          path: spec.metrics[1].resource.name
+          value: memory
+      - equal:
+          path: spec.metrics[1].resource.target.type
+          value: Utilization
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 75
+
+  - it: Should scale at configured Memory utilization
+    set:
+      deployment:
+        averageMemoryUtilization: 50
+    template: kubernetes/hpa.yaml
+    asserts:
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 50

--- a/charts/app/tests/kubernetes_hpa_test.yaml
+++ b/charts/app/tests/kubernetes_hpa_test.yaml
@@ -45,7 +45,7 @@ tests:
           path: spec.maxReplicas
           value: 10
 
-  - it: Should scale at 95% CPU utilization by default
+  - it: Should scale at 80% CPU utilization by default
     set:
       template: kubernetes/hpa.yaml
     asserts:

--- a/charts/app/tests/kubernetes_hpa_test.yaml
+++ b/charts/app/tests/kubernetes_hpa_test.yaml
@@ -45,7 +45,7 @@ tests:
           path: spec.maxReplicas
           value: 10
 
-  - it: Should scale at 80% CPU utilization by default
+  - it: Should scale at 96% CPU utilization by default
     set:
       template: kubernetes/hpa.yaml
     asserts:
@@ -60,7 +60,7 @@ tests:
           value: Utilization
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
-          value: 80
+          value: 95
 
   - it: Should scale at configured CPU utilization
     set:

--- a/charts/app/tests/kubernetes_hpa_test.yaml
+++ b/charts/app/tests/kubernetes_hpa_test.yaml
@@ -44,3 +44,20 @@ tests:
       - equal:
           path: spec.maxReplicas
           value: 10
+
+  - it: Should scale at 95% CPU utilization by default
+    set:
+      template: kubernetes/hpa.yaml
+    asserts:
+      - equal:
+          path: spec.metrics[0].type
+          value: Resource
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.target.type
+          value: Utilization
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 95

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -285,9 +285,9 @@ deployment:
   # @section -- application
   maxReplicas: null
   # deployment.averageCpuUtilization -- (int) The target average CPU utilization percentage for the HorizontalPodAutoscaler
-  # @default -- `95`
+  # @default -- `80`
   # @section -- application
-  averageCpuUtilization: 95
+  averageCpuUtilization: 80
   # deployment.averageMemoryUtilization -- (int) The target average Memory utilization percentage for the HorizontalPodAutoscaler
   # @default -- `75`
   # @section -- application

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -284,6 +284,10 @@ deployment:
   # @default -- `.Values.deployment.replicas
   # @section -- application
   maxReplicas: null
+  # deployment.averageUtilization -- (int) The target average CPU utilization percentage for the HorizontalPodAutoscaler
+  # @default -- `95`
+  # @section -- application
+  averageUtilization: 95
 ports:
   app-port:
     # ports.app-port.port -- The port the application is listening on

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -287,7 +287,7 @@ deployment:
   # deployment.averageCpuUtilization -- (int) The target average CPU utilization percentage for the HorizontalPodAutoscaler
   # @default -- `80`
   # @section -- application
-  averageCpuUtilization: 80
+  averageCpuUtilization: 95
   # deployment.averageMemoryUtilization -- (int) The target average Memory utilization percentage for the HorizontalPodAutoscaler
   # @default -- `75`
   # @section -- application

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -284,10 +284,15 @@ deployment:
   # @default -- `.Values.deployment.replicas
   # @section -- application
   maxReplicas: null
-  # deployment.averageUtilization -- (int) The target average CPU utilization percentage for the HorizontalPodAutoscaler
+  # deployment.averageCpuUtilization -- (int) The target average CPU utilization percentage for the HorizontalPodAutoscaler
   # @default -- `95`
   # @section -- application
-  averageUtilization: 95
+  averageCpuUtilization: 95
+  # deployment.averageMemoryUtilization -- (int) The target average Memory utilization percentage for the HorizontalPodAutoscaler
+  # @default -- `75`
+  # @section -- application
+  averageMemoryUtilization: 75
+
 ports:
   app-port:
     # ports.app-port.port -- The port the application is listening on

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -289,9 +289,9 @@ deployment:
   # @section -- application
   averageCpuUtilization: 95
   # deployment.averageMemoryUtilization -- (int) The target average Memory utilization percentage for the HorizontalPodAutoscaler
-  # @default -- `75`
+  # @default -- `disabled`
   # @section -- application
-  averageMemoryUtilization: 75
+  averageMemoryUtilization: null
 
 ports:
   app-port:


### PR DESCRIPTION
I added the ability to modify the HorizontalPodAutoscaler attributes so that we could configure our services to scale at different cpu and memory utilizations.


I also changed the default auto scaling from 95% -> 80% cpu utilization. Feel free to decline that commit (the last one).