### PR TITLE
Remove OPTIONS cachedMethod when allowedMethods is set to "read"

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common infrastructure
 
 type: application
 
-version: 0.15.0
+version: 0.15.1
 
-appVersion: 0.15.0
+appVersion: 0.15.1
 
 keywords:
   - infra

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -1,6 +1,6 @@
 # infra
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.0](https://img.shields.io/badge/AppVersion-0.15.0-informational?style=flat-square)
+![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.1](https://img.shields.io/badge/AppVersion-0.15.1-informational?style=flat-square)
 
 A Helm "monochart" for deploying common infrastructure
 

--- a/charts/infra/templates/cloudfrontrouter.yaml
+++ b/charts/infra/templates/cloudfrontrouter.yaml
@@ -74,10 +74,12 @@ spec:
     {{- range $resolvedHttpMethods }}
       - {{ . }}
     {{- end }}
+    {{- if ne $httpMethodKey "read" }}  # Remove cachedMethods if "read" is selected
     cachedMethods:
       - GET
       - HEAD
       - OPTIONS
+    {{- end }}
     compress: true
     pathPattern: {{ $pathPattern }}
     targetOriginId: {{ $targetOriginId }}

--- a/charts/infra/templates/cloudfrontrouter.yaml
+++ b/charts/infra/templates/cloudfrontrouter.yaml
@@ -74,10 +74,10 @@ spec:
     {{- range $resolvedHttpMethods }}
       - {{ . }}
     {{- end }}
-    {{- if ne $httpMethodKey "read" }}  # Remove cachedMethods if "read" is selected
     cachedMethods:
       - GET
       - HEAD
+    {{- if ne $httpMethodKey "read" }}
       - OPTIONS
     {{- end }}
     compress: true

--- a/charts/infra/tests/cloudfrontrouter_test.yaml
+++ b/charts/infra/tests/cloudfrontrouter_test.yaml
@@ -124,6 +124,9 @@ tests:
                 - GET
                 - HEAD
               cachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+              cachedMethods:
+                - GET
+                - HEAD
               compress: true
               customCachePolicyName: web-updates
               originRequestPolicyId: b689b0a8-53d0-40ab-baf2-68738e2966ac

--- a/charts/infra/tests/cloudfrontrouter_test.yaml
+++ b/charts/infra/tests/cloudfrontrouter_test.yaml
@@ -124,10 +124,6 @@ tests:
                 - GET
                 - HEAD
               cachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
-              cachedMethods:
-                - GET
-                - HEAD
-                - OPTIONS
               compress: true
               customCachePolicyName: web-updates
               originRequestPolicyId: b689b0a8-53d0-40ab-baf2-68738e2966ac


### PR DESCRIPTION
Attempt to fix  InvalidArgument: "The parameter CachedMethods OPTIONS does not exist in AllowedMethods" when read is selected as it does not contain OPTIONS