### PR TITLE
TECH- 963 Make deploy time logs easier to find / view / debug

### DIFF
--- a/charts/app/templates/alloy/podlogs.yaml
+++ b/charts/app/templates/alloy/podlogs.yaml
@@ -30,3 +30,7 @@ spec:
       sourceLabels:
         - __meta_kubernetes_pod_uid
       targetLabel: pod_uid
+    - action: replace
+      sourceLabels:
+        - __meta_kubernetes_pod_label_app_kubernetes_io_version
+      targetLabel: release_version

--- a/charts/app/tests/alloy_podlogs_test.yaml
+++ b/charts/app/tests/alloy_podlogs_test.yaml
@@ -42,3 +42,7 @@ tests:
                 sourceLabels:
                 - __meta_kubernetes_pod_uid
                 targetLabel: pod_uid
+              - action: replace
+                sourceLabels:
+                  - __meta_kubernetes_pod_label_app_kubernetes_io_version
+                targetLabel: release_version


### PR DESCRIPTION
Adding a relabelling for the following source label `__meta_kubernetes_pod_label_app_kubernetes_io_version`

Looking at docs it seems the following `app.kubernetes.io/version` is converter to an underscored label