### PR TITLE
Make probe timeouts configurable with default 2 seconds

### DIFF
--- a/charts/app/templates/kubernetes/_podtemplate.tpl
+++ b/charts/app/templates/kubernetes/_podtemplate.tpl
@@ -47,7 +47,7 @@ Outputs a pod spec for use in different resources.
             scheme: HTTP
           failureThreshold: 60
           periodSeconds: 5
-          timeoutSeconds: 2
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
         readinessProbe:
           httpGet:
             path: {{ .Values.healthcheckEndpoint.path }}
@@ -56,7 +56,7 @@ Outputs a pod spec for use in different resources.
           failureThreshold: 1
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 2
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
         livenessProbe:
           httpGet:
             path: {{ .Values.healthcheckEndpoint.path }}
@@ -65,7 +65,7 @@ Outputs a pod spec for use in different resources.
           failureThreshold: 3
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 2
+          timeoutSeconds: {{ .Values.probes.timeoutSeconds }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -156,6 +156,10 @@ healthcheckEndpoint:
   # healthcheckEndpoint.port -- TThe name of the port that the healthcheck endpoint is listening on
   # @section -- application
   port: app-port
+probes:
+  # probes.timeoutSeconds -- The timeout in seconds for startup, readiness and liveness probes
+  # @section -- application
+  timeoutSeconds: 2
 resources:
   # resources.cpu -- Requested CPU time for the pod
   # @section -- application


### PR DESCRIPTION
- Add probes.timeoutSeconds configuration to values.yaml
- Update _podtemplate.tpl to use configurable timeout for all probes
- Maintains backward compatibility with default 2 second timeout

🤖 Generated with [Claude Code](https://claude.ai/code)