### PR TITLE
feat: add configurable interval to PodMonitor template

### DIFF
--- a/charts/app/templates/alloy/podmonitor.yaml
+++ b/charts/app/templates/alloy/podmonitor.yaml
@@ -9,7 +9,7 @@ spec:
     matchNames:
     -  {{ .Release.Namespace }}
   podMetricsEndpoints:
-  - interval: 15s
+  - interval: {{ .Values.metricsEndpoint.interval }}
     path: {{ .Values.metricsEndpoint.path }}
     port: {{ .Values.metricsEndpoint.port }}
     honorLabels: {{ .Values.metricsEndpoint.honorLabels }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -146,9 +146,12 @@ metricsEndpoint:
   # metricsEndpoint.port -- The name of the port that the metrics endpoint is listening on
   # @section -- application
   port: app-port
-  # metricsEndpoint.honorLabels -- When `true`, honorLabels preserves the metric’s labels when they collide with the target’s labels.
+  # metricsEndpoint.honorLabels -- When `true`, honorLabels preserves the metric's labels when they collide with the target's labels.
   # @section -- application
   honorLabels: false
+  # metricsEndpoint.interval -- The interval at which metrics are scraped from the endpoint
+  # @section -- application
+  interval: 15s
 healthcheckEndpoint:
   # healthcheckEndpoint.path -- The path of the applications HTTP healthcheck endpoint
   # @section -- application


### PR DESCRIPTION
- Add metricsEndpoint.interval configuration option in values.yaml
- Update PodMonitor template to use configurable interval
- Maintain backward compatibility with default 15s interval

🤖 Generated with [Claude Code](https://claude.ai/code)