### PR TITLE
feat: add flipt integration support

### DIFF
--- a/charts/app/templates/cilium/networkpolicy.yaml
+++ b/charts/app/templates/cilium/networkpolicy.yaml
@@ -186,6 +186,18 @@ spec:
             protocol: TCP
   {{- end }}
 
+  {{- if .Values.infra.flipt.enabled }}
+  # Network policy to allow communication with platform-flipt service
+  - toEndpoints:
+    - matchLabels:
+        app.kubernetes.io/app: platform-flipt
+        k8s:io.kubernetes.pod.namespace: platform
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+  {{- end }}
+
   {{- with .Values.ciliumNetworkPolicy.externalHttpsServices }}
   - toFQDNs:
     {{- range . }}

--- a/charts/app/templates/kubernetes/_podtemplate.tpl
+++ b/charts/app/templates/kubernetes/_podtemplate.tpl
@@ -14,6 +14,9 @@ Outputs a pod spec for use in different resources.
       {{- end }}
       labels:
       {{- include "app.labels" . | nindent 8 }}
+      {{- if .Values.infra.flipt.enabled }}
+        flipt-enabled: "flipt-enabled"
+      {{- end }}
       {{- with .Values.pod.labels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -449,6 +449,11 @@ infra:
   #      retainIndefinitely: false
   #      retentionPeriod: "15d"
 
+  flipt:
+    # infra.flipt.enabled -- Set to `true` to enable integration with platform-flipt service
+    # @section -- infra
+    enabled: false
+
 # extraDeploy -- Extra Kubernetes configuration
 extraDeploy: []
 # preDeployCommand -- (string[]) Command to run before install and upgrade of your application. See examples in values.yaml


### PR DESCRIPTION
## Summary
- Add `infra.flipt.enabled` flag to enable platform-flipt service integration
- Add Cilium network policy egress rule for platform-flipt communication
- Add `flipt-enabled: "flipt-enabled"` pod label for access control

## Changes Made
- **values.yaml**: Added `infra.flipt.enabled` flag following existing infrastructure service patterns
- **networkpolicy.yaml**: Added conditional egress rule to allow communication with platform-flipt service on port 8080
- **_podtemplate.tpl**: Added conditional pod label when flipt integration is enabled

## Test Plan
- [x] Verified templates render correctly with `infra.flipt.enabled: true`
- [x] Verified no flipt references when `infra.flipt.enabled: false` 
- [x] Validated YAML syntax and Helm template compilation
- [x] Follows existing infrastructure service patterns (postgres, redis, bedrock, etc.)

## Usage
Applications can enable Flipt integration by setting:
```yaml
infra:
  flipt:
    enabled: true
```

The Flipt service can then allow access using:
```yaml
ciliumNetworkPolicy:
  fromApps:
  - flipt-enabled: "flipt-enabled"
```

Resolves TECH-1050

🤖 Generated with [Claude Code](https://claude.ai/code)