### PR TITLE
chore: bump app chart to 0.29.2 with infra 0.22.8 for gRPC support

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common application patterns
 
 type: application
 
-version: 0.29.1
+version: 0.29.2
 
-appVersion: 0.29.1
+appVersion: 0.29.2
 
 keywords:
   - app
@@ -14,5 +14,5 @@ keywords:
 
 dependencies:
   - name: infra
-    version: 0.22.7
+    version: 0.22.8
     repository: https://portswigger-apps.github.io/helm-charts/

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.29.1](https://img.shields.io/badge/Version-0.29.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.1](https://img.shields.io/badge/AppVersion-0.29.1-informational?style=flat-square)
+![Version: 0.29.2](https://img.shields.io/badge/Version-0.29.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.2](https://img.shields.io/badge/AppVersion-0.29.2-informational?style=flat-square)
 
 A Helm "monochart" for deploying common application patterns
 
@@ -14,7 +14,7 @@ helm install app helm-charts/app
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://portswigger-apps.github.io/helm-charts/ | infra | 0.22.7 |
+| https://portswigger-apps.github.io/helm-charts/ | infra | 0.22.8 |
 
 ## Values
 


### PR DESCRIPTION
Updates app chart from 0.29.1 to 0.29.2 with infra dependency upgraded from 0.22.7 to 0.22.8 to enable gRPC support in CloudFront.

Changes:
- Bump app chart version to 0.29.2
- Update infra dependency to 0.22.8 (includes grpcEnabled field)
- Update README with new version and dependency info

Related: platform-flipt gRPC enablement