### PR TITLE
fix: grpcEnabled should be boolean not string in CloudFrontSite

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common infrastructure
 
 type: application
 
-version: 0.22.8
+version: 0.22.9
 
-appVersion: 0.22.8
+appVersion: 0.22.9
 
 keywords:
   - infra

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -1,6 +1,6 @@
 # infra
 
-![Version: 0.22.8](https://img.shields.io/badge/Version-0.22.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.8](https://img.shields.io/badge/AppVersion-0.22.8-informational?style=flat-square)
+![Version: 0.22.9](https://img.shields.io/badge/Version-0.22.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.9](https://img.shields.io/badge/AppVersion-0.22.9-informational?style=flat-square)
 
 A Helm "monochart" for deploying common infrastructure
 

--- a/charts/infra/templates/cloudfrontsite.yaml
+++ b/charts/infra/templates/cloudfrontsite.yaml
@@ -13,7 +13,7 @@ spec:
   defaultCacheBehavior:
     {{- omit .Values.cloudfront.defaultCacheBehavior "grpcEnabled" | toYaml | nindent 4 }}
     {{- if hasKey .Values.cloudfront.defaultCacheBehavior "grpcEnabled" }}
-    grpcEnabled: {{ .Values.cloudfront.defaultCacheBehavior.grpcEnabled | quote }}
+    grpcEnabled: {{ .Values.cloudfront.defaultCacheBehavior.grpcEnabled }}
     {{- end }}
   restrictToOffice: {{ .Values.cloudfront.restrictToOffice | quote}}
 {{- end -}}

--- a/charts/infra/tests/cloudfrontsite_test.yaml
+++ b/charts/infra/tests/cloudfrontsite_test.yaml
@@ -67,7 +67,7 @@ tests:
             defaultTtl: 3601
             minTtl: 0
             maxTtl: 31536000
-            grpcEnabled: "false"
+            grpcEnabled: false
             cookies:
               behavior: allowlist
               allowlistedNames:
@@ -98,4 +98,4 @@ tests:
           value: all
       - equal:
           path: spec.defaultCacheBehavior.grpcEnabled
-          value: "true"
+          value: true


### PR DESCRIPTION
The grpcEnabled field was being quoted in the template, causing Kubernetes validation to fail with "must be of type boolean: string".

Changes:
- Remove | quote from grpcEnabled template
- Bump infra chart version to 0.22.9
- Update README with new version
- Fix test assertion to expect boolean true instead of string "true"

Fixes deployment error:
CloudFrontSite.platform.portswigger.io is invalid: spec.defaultCacheBehavior.grpcEnabled: Invalid value: "string": spec.defaultCacheBehavior.grpcEnabled in body must be of type boolean: "string"