### PR TITLE
chore: bump app chart to 0.29.3 with infra 0.22.9

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common application patterns
 
 type: application
 
-version: 0.29.2
+version: 0.29.3
 
-appVersion: 0.29.2
+appVersion: 0.29.3
 
 keywords:
   - app
@@ -14,5 +14,5 @@ keywords:
 
 dependencies:
   - name: infra
-    version: 0.22.8
+    version: 0.22.9
     repository: https://portswigger-apps.github.io/helm-charts/

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.29.2](https://img.shields.io/badge/Version-0.29.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.2](https://img.shields.io/badge/AppVersion-0.29.2-informational?style=flat-square)
+![Version: 0.29.3](https://img.shields.io/badge/Version-0.29.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.3](https://img.shields.io/badge/AppVersion-0.29.3-informational?style=flat-square)
 
 A Helm "monochart" for deploying common application patterns
 
@@ -14,7 +14,7 @@ helm install app helm-charts/app
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://portswigger-apps.github.io/helm-charts/ | infra | 0.22.8 |
+| https://portswigger-apps.github.io/helm-charts/ | infra | 0.22.9 |
 
 ## Values
 


### PR DESCRIPTION
Updates app chart from 0.29.2 to 0.29.3 with infra dependency upgraded from 0.22.8 to 0.22.9 to fix grpcEnabled boolean type issue.

Changes:
- Bump app chart version to 0.29.3
- Update infra dependency to 0.22.9 (fixes grpcEnabled rendering as string)
- Update README with new version and dependency info

Related:
- infra fix: grpcEnabled boolean type correction
- Resolves deployment error with grpcEnabled field