### PR TITLE
feat(app): configurable PDB and probe endpoints (BAE-783)

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common application patterns
 
 type: application
 
-version: 0.45.0
+version: 0.46.0
 
-appVersion: 0.45.0
+appVersion: 0.46.0
 
 keywords:
   - app

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.45.0](https://img.shields.io/badge/Version-0.45.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.45.0](https://img.shields.io/badge/AppVersion-0.45.0-informational?style=flat-square)
+![Version: 0.46.0](https://img.shields.io/badge/Version-0.46.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.46.0](https://img.shields.io/badge/AppVersion-0.46.0-informational?style=flat-square)
 
 A Helm "monochart" for deploying common application patterns
 
@@ -57,6 +57,8 @@ helm install app helm-charts/app
 | deployment.averageCpuUtilization | int | `9` | The target average CPU utilization percentage for the HorizontalPodAutoscaler |
 | deployment.averageMemoryUtilization | int | `disabled` | The target average Memory utilization percentage for the HorizontalPodAutoscaler |
 | deployment.customAutoscalingMetrics | list | `disabled` | Advanced: A list of custom metrics scalers. |
+| pdb.maxUnavailable | string | `"50%"` | Maximum pods that may be voluntarily disrupted at one time. Absolute integer (e.g. `1`) or percentage (e.g. `"50%"`). Only applied when `deployment.replicas > 1`. Mutually exclusive with `pdb.minAvailable`. |
+| pdb.minAvailable | string | `nil` | Minimum pods that must remain available. When set, takes precedence over `maxUnavailable`. Absolute integer or percentage. |
 | ports.app-port.port | int | `8080` | The port the application is listening on |
 | ports.app-port.protocol | string | `"TCP"` | The protocol the application uses. This should alost always be TCP |
 | ports.app-port.expose | bool | `true` | Whether the port should be accessible to the cluster and outside world |
@@ -66,6 +68,8 @@ helm install app helm-charts/app
 | metricsEndpoint.interval | string | `"15s"` | The interval at which metrics are scraped from the endpoint |
 | healthcheckEndpoint.path | string | `"/health"` | The path of the applications HTTP healthcheck endpoint |
 | healthcheckEndpoint.port | string | `"app-port"` | TThe name of the port that the healthcheck endpoint is listening on |
+| livenessEndpoint | object | `{}` | Override `healthcheckEndpoint` for the **liveness** probe only. Liveness should be cheap and check only "is the process responsive" with no database or downstream dependency checks. Keys set here override the matching keys in `healthcheckEndpoint`; unset keys fall through. Leave as `{}` to inherit the existing `healthcheckEndpoint` (preserves chart pre-0.46.0 behaviour). |
+| readinessEndpoint | object | `{}` | Override `healthcheckEndpoint` for the **readiness** probe (and startup probe, which mirrors it). Readiness can legitimately go red on transient downstream blips without warranting a pod restart. Keys set here override the matching keys in `healthcheckEndpoint`; unset keys fall through. |
 | resources.cpu | string | `"100m"` | Requested CPU time for the pod |
 | resources.memory | string | `"64Mi"` | Maximum memory usage for the pod |
 

--- a/charts/app/templates/kubernetes/_podtemplate.tpl
+++ b/charts/app/templates/kubernetes/_podtemplate.tpl
@@ -3,18 +3,22 @@
 {{/*
 Outputs a configured healthcheck used in startup, liveness and readiness probes.
 gRPC requires port number, http can use port name.
+
+Argument: a dict with keys
+  endpoint - the resolved endpoint config (type, path, port, grpcService)
+  ports    - the ports map (typically .Values.ports)
 */}}
 {{- define "app.healthcheck" }}
-{{- if eq .Values.healthcheckEndpoint.type "grpc" }}
+{{- if eq .endpoint.type "grpc" }}
 grpc:
-  port: {{ (get (get .Values.ports (toString .Values.healthcheckEndpoint.port) | default dict) "port") | default .Values.healthcheckEndpoint.port }}
-  {{- with .Values.healthcheckEndpoint.grpcService }}
+  port: {{ (get (get .ports (toString .endpoint.port) | default dict) "port") | default .endpoint.port }}
+  {{- with .endpoint.grpcService }}
   service: {{ . }}
   {{- end }}
-{{- else if eq .Values.healthcheckEndpoint.type "http" }}
+{{- else if eq .endpoint.type "http" }}
 httpGet:
-  path: {{ .Values.healthcheckEndpoint.path }}
-  port: {{ .Values.healthcheckEndpoint.port }}
+  path: {{ .endpoint.path }}
+  port: {{ .endpoint.port }}
   scheme: HTTP
 {{- end }}
 {{- end }}
@@ -67,19 +71,21 @@ Outputs a pod spec for use in different resources.
             containerPort: {{ $portSpec.port }}
             protocol: {{ $portSpec.protocol }}
         {{- end }}
+        {{- $readinessEndpoint := mergeOverwrite (deepCopy .Values.healthcheckEndpoint) (.Values.readinessEndpoint | default dict) }}
+        {{- $livenessEndpoint := mergeOverwrite (deepCopy .Values.healthcheckEndpoint) (.Values.livenessEndpoint | default dict) }}
         startupProbe:
-          {{ include "app.healthcheck" . | nindent 10 }}
+          {{ include "app.healthcheck" (dict "endpoint" $readinessEndpoint "ports" .Values.ports) | nindent 10 }}
           failureThreshold: 60
           periodSeconds: 5
           timeoutSeconds: 2
         readinessProbe:
-          {{ include "app.healthcheck" . | nindent 10 }}
+          {{ include "app.healthcheck" (dict "endpoint" $readinessEndpoint "ports" .Values.ports) | nindent 10 }}
           failureThreshold: 1
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
         livenessProbe:
-          {{ include "app.healthcheck" . | nindent 10 }}
+          {{ include "app.healthcheck" (dict "endpoint" $livenessEndpoint "ports" .Values.ports) | nindent 10 }}
           failureThreshold: 3
           periodSeconds: 10
           successThreshold: 1

--- a/charts/app/templates/kubernetes/pdb.yaml
+++ b/charts/app/templates/kubernetes/pdb.yaml
@@ -9,5 +9,9 @@ spec:
   selector:
     matchLabels:
       {{- include "app.labelselector" . | nindent 6 }}
-  maxUnavailable: 50%
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
 {{- end -}}

--- a/charts/app/tests/kubernetes_deployment_test.yaml
+++ b/charts/app/tests/kubernetes_deployment_test.yaml
@@ -269,6 +269,19 @@ tests:
             port: metrics-port
             scheme: HTTP
 
+  - it: should render mixed-protocol probes when livenessEndpoint overrides type to grpc
+    template: kubernetes/deployment.yaml
+    set:
+      livenessEndpoint:
+        type: grpc
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].livenessProbe.grpc
+      - exists:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].readinessProbe.httpGet
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].livenessProbe.httpGet
+
   - it: should create Deployment with default ports configured
     template: kubernetes/deployment.yaml
     asserts:

--- a/charts/app/tests/kubernetes_deployment_test.yaml
+++ b/charts/app/tests/kubernetes_deployment_test.yaml
@@ -200,6 +200,75 @@ tests:
             periodSeconds: 10
             timeoutSeconds: 2
 
+  - it: should apply livenessEndpoint to the liveness probe only when set
+    template: kubernetes/deployment.yaml
+    set:
+      livenessEndpoint:
+        path: /livez
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].livenessProbe.httpGet.path
+          value: /livez
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].readinessProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].startupProbe.httpGet.path
+          value: /health
+
+  - it: should apply readinessEndpoint to readiness and startup probes only when set
+    template: kubernetes/deployment.yaml
+    set:
+      readinessEndpoint:
+        path: /readyz
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].startupProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].livenessProbe.httpGet.path
+          value: /health
+
+  - it: should apply both liveness and readiness overrides independently
+    template: kubernetes/deployment.yaml
+    set:
+      livenessEndpoint:
+        path: /livez
+      readinessEndpoint:
+        path: /readyz
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].livenessProbe.httpGet.path
+          value: /livez
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].startupProbe.httpGet.path
+          value: /readyz
+
+  - it: should inherit healthcheckEndpoint port when only path is overridden in livenessEndpoint
+    template: kubernetes/deployment.yaml
+    set:
+      ports:
+        metrics-port:
+          port: 9090
+          protocol: TCP
+      healthcheckEndpoint:
+        port: metrics-port
+      livenessEndpoint:
+        path: /livez
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].livenessProbe.httpGet
+          value:
+            path: /livez
+            port: metrics-port
+            scheme: HTTP
+
   - it: should create Deployment with default ports configured
     template: kubernetes/deployment.yaml
     asserts:

--- a/charts/app/tests/kubernetes_pdb_test.yaml
+++ b/charts/app/tests/kubernetes_pdb_test.yaml
@@ -18,3 +18,41 @@ tests:
           count: 1
       - isKind:
           of: PodDisruptionBudget
+
+  - it: should default to maxUnavailable 50% when replicas is greater than 1
+    set:
+      deployment:
+        replicas: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: "50%"
+      - notExists:
+          path: spec.minAvailable
+
+  - it: should honour a custom maxUnavailable value
+    set:
+      deployment:
+        replicas: 2
+      pdb:
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: should use minAvailable when set, taking precedence over maxUnavailable
+    set:
+      deployment:
+        replicas: 3
+      pdb:
+        minAvailable: 2
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -136,6 +136,16 @@ deployment:
     # deployment.terminationDelay.delaySeconds -- The number of seconds the pod will stay in `terminating` state before a SIGTERM is sent
     # @section -- application
     delaySeconds: 15
+pdb:
+  # pdb.maxUnavailable -- Maximum pods that may be voluntarily disrupted at one time.
+  # Absolute integer (e.g. `1`) or percentage (e.g. `"50%"`). Only applied when
+  # `deployment.replicas > 1`. Mutually exclusive with `pdb.minAvailable`.
+  # @section -- application
+  maxUnavailable: "50%"
+  # pdb.minAvailable -- Minimum pods that must remain available. When set, takes
+  # precedence over `maxUnavailable`. Absolute integer or percentage.
+  # @section -- application
+  minAvailable: null
 ports:
   app-port:
     # ports.app-port.port -- The port the application is listening on
@@ -177,6 +187,21 @@ healthcheckEndpoint:
   # healthcheckEndpoint.port -- TThe name of the port that the healthcheck endpoint is listening on
   # @section -- application
   port: app-port
+# livenessEndpoint -- Override `healthcheckEndpoint` for the **liveness** probe only.
+# Liveness should be cheap and check only "is the process responsive" with no
+# database or downstream dependency checks. Keys set here override the matching
+# keys in `healthcheckEndpoint`; unset keys fall through. Leave as `{}` to inherit
+# the existing `healthcheckEndpoint` (preserves chart pre-0.46.0 behaviour).
+# @section -- application
+livenessEndpoint: {}
+# livenessEndpoint:
+#   path: /livez
+# readinessEndpoint -- Override `healthcheckEndpoint` for the **readiness** probe
+# (and startup probe, which mirrors it). Readiness can legitimately go red on
+# transient downstream blips without warranting a pod restart. Keys set here
+# override the matching keys in `healthcheckEndpoint`; unset keys fall through.
+# @section -- application
+readinessEndpoint: {}
 resources:
   # resources.cpu -- Requested CPU time for the pod
   # @section -- application


### PR DESCRIPTION
  Part 1 of 2 — purely additive. Adds opt-in pdb.*, livenessEndpoint,
  and readinessEndpoint values; defaults preserve current behaviour.
  Merging so 0.46.0 publishes and the gateway can opt in on dev.

## Summary
  - Exposes `pdb.maxUnavailable` and `pdb.minAvailable` so services can override the PDB
  - Adds `livenessEndpoint` and `readinessEndpoint` for services that want to split the conflated `/health` probe
  - **Defaults preserve current behaviour** — chart still renders `maxUnavailable: 50%`, and all three probes still use `healthcheckEndpoint` unless
  services opt in

  ## Motivation
  On 2026-05-06 both `hakawai-gateway` pods crash-looped during a Karpenter consolidation, causing a full outage. Two structural weaknesses combined:
  liveness and readiness shared one endpoint that checks the database (a transient DB blip both killed pods *and* lied to the PDB about readiness), and
   the hardcoded `maxUnavailable: 50%` doesn't help at high replica counts.

  This is **part 1 of 2** (`BAE-783`). It's purely additive — no service inherits any behaviour change. The follow-up on `hakawai-gateway` will opt in
  to `pdb.maxUnavailable: 1` and `livenessEndpoint.path: /livez`, with a new cheap `/livez` endpoint added there.

  ## Test plan
  - [x] `helm lint charts/app` clean
  - [x] `helm unittest --strict charts/app` — 158 tests pass (existing + new PDB and probe-override cases)
  - [x] `helm-docs` regenerated `charts/app/README.md`
  - [ ] CI green

  ## Out of scope
  - Changing chart defaults fleet-wide — affects non-Hakawai services on the shared platform; happy to discuss as a follow-up.
  - The Beyla/aarch64 bug that triggered the May 6 outage (tracked separately).

## Part 2
  - Part 2 lands in hakawai-gateway and doesn't touch this repo — bumps to chart 0.46.0, adds a cheap /livez endpoint, and opts in to the new values. 
  - Adopting the same pattern across the rest of the fleet is follow-up work, tracked separately per service.