### PR TITLE
feat: edgeAllowlist passthrough for infra/app charts (PLAT-450)

### DIFF
--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -108,6 +108,7 @@ helm install app helm-charts/app
 | infra.cloudfront.domainName | string | `""` | The presentation domain name for the `CloudFrontSite` resource |
 | infra.cloudfront.targetOriginDomainName | string | `.Values.global.ingress.host` | The target origin domain name that the `CloudFrontSite` resource fronts |
 | infra.cloudfront.restrictToOffice | bool | `true` | Set to `false` to allow access to the `CloudFrontSite` outside of the office IPs. (managed outside of app-chart) |
+| infra.cloudfront.edgeAllowlist | string | `""` | Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `infra.cloudfront.restrictToOffice`. (managed outside of app-chart) |
 | infra.cloudfront.originHeaderAuth | bool | `true` | Set to 'true' to enable authentication between CloudFront and the origin |
 | infra.cloudfront.defaultCacheBehavior.allowedMethods | string | `"read"` | Whether `read` or `all` HTTP methods are allowed by the `CloudFrontSite` |
 | infra.cloudfront.defaultCacheBehavior.minTtl | int | `0` | The minimum time-to-live for the `CloudFrontSite` cache objects |

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -381,6 +381,9 @@ infra:
     # infra.cloudfront.restrictToOffice -- Set to `false` to allow access to the `CloudFrontSite` outside of the office IPs. (managed outside of app-chart)
     # @section -- infra
     restrictToOffice: true
+    # infra.cloudfront.edgeAllowlist -- Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `infra.cloudfront.restrictToOffice`. (managed outside of app-chart)
+    # @section -- infra
+    edgeAllowlist: ""
     # infra.cloudfront.originHeaderAuth -- Set to 'true' to enable authentication between CloudFront and the origin
     # @section -- infra
     originHeaderAuth: true

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -51,6 +51,7 @@ helm install infra helm-charts/infra
 | cloudfront.domainName | string | `""` | The presentation domain name for the `CloudFrontSite` resource |
 | cloudfront.targetOriginDomainName | string | `.Values.global.ingress.host` | The target origin domain name that the `CloudFrontSite` resource fronts |
 | cloudfront.restrictToOffice | bool | `true` | Set to `true` to restrict access to the `CloudFrontSite` to the office IP ranges |
+| cloudfront.edgeAllowlist | string | unset | Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `cloudfront.restrictToOffice`. Leave unset to keep using `restrictToOffice`. |
 | cloudfront.wildcard | bool | `false` | Allows for requests to domain name with wildcard *.domainName |
 | cloudfront.geoRestriction.restrictionType | string | `"none"` | Whether to `allow` or `deny` the configured locations access to the `CloudFrontSite`. Set to `none` to remove all restrictions |
 | cloudfront.geoRestriction.locations | list | `[]` | A list of ISO ALPHA-2 country codes to apply restrictions to |

--- a/charts/infra/templates/cloudfrontsite.yaml
+++ b/charts/infra/templates/cloudfrontsite.yaml
@@ -19,4 +19,7 @@ spec:
     grpcEnabled: {{ .Values.cloudfront.defaultCacheBehavior.grpcEnabled }}
     {{- end }}
   restrictToOffice: {{ .Values.cloudfront.restrictToOffice | quote}}
+  {{- with .Values.cloudfront.edgeAllowlist }}
+  edgeAllowlist: {{ . | quote }}
+  {{- end }}
 {{- end -}}

--- a/charts/infra/tests/cloudfrontsite_test.yaml
+++ b/charts/infra/tests/cloudfrontsite_test.yaml
@@ -81,6 +81,46 @@ tests:
               allowlistedNames:
                 - my-query-string
 
+  - it: should emit edgeAllowlist when set and still emit restrictToOffice
+    set:
+      global:
+        ingress:
+          host: example.com
+      cloudfront:
+        enabled: true
+        restrictToOffice: true
+        edgeAllowlist: office-auth0
+        domainName: cloudfront.example.com
+        hostedZoneId: ZABCDEFGHIJKL
+        defaultCacheBehavior:
+          allowedMethods: all
+    asserts:
+      - equal:
+          path: spec.edgeAllowlist
+          value: office-auth0
+      - equal:
+          path: spec.restrictToOffice
+          value: "true"
+
+  - it: should NOT emit edgeAllowlist when unset (back-compat)
+    set:
+      global:
+        ingress:
+          host: example.com
+      cloudfront:
+        enabled: true
+        restrictToOffice: true
+        domainName: cloudfront.example.com
+        hostedZoneId: ZABCDEFGHIJKL
+        defaultCacheBehavior:
+          allowedMethods: all
+    asserts:
+      - notExists:
+          path: spec.edgeAllowlist
+      - equal:
+          path: spec.restrictToOffice
+          value: "true"
+
   - it: should create a CloudFrontSite with gRPC enabled
     set:
       cloudfront:

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -104,6 +104,11 @@ cloudfront:
   # @section -- cloudfront
   restrictToOffice: true
 
+  # cloudfront.edgeAllowlist -- Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `cloudfront.restrictToOffice`. Leave unset to keep using `restrictToOffice`.
+  # @default -- unset
+  # @section -- cloudfront
+  edgeAllowlist: ""
+
   # cloudfront.wildcard -- Allows for requests to domain name with wildcard *.domainName
   # @section -- cloudfront
   wildcard: false


### PR DESCRIPTION
PR 3 of 3 for PLAT-450.

Optional `cloudfront.edgeAllowlist` (`public|office|office-auth0`) emitted onto the CloudFrontSite claim only when set, so it supersedes `restrictToOffice` without affecting existing apps. Adds helm-unittest cases for the set/unset paths.

**Before release:** Chart.yaml version bumps (infra 0.26.0->0.27.0, app infra-dependency + 0.46.1->0.47.0) and `helm dependency update` still needed — left out so the maintainer can set them per release convention and regenerate Chart.lock.

Depends on the platform composition PR being deployed (XRD must accept `edgeAllowlist`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)