### PR TITLE
Revert "feat: add edgeAllowlist passthrough" (#31) to restore OCI 0.26.0/0.46.1 (PLAT-450)

### DIFF
--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -108,7 +108,6 @@ helm install app helm-charts/app
 | infra.cloudfront.domainName | string | `""` | The presentation domain name for the `CloudFrontSite` resource |
 | infra.cloudfront.targetOriginDomainName | string | `.Values.global.ingress.host` | The target origin domain name that the `CloudFrontSite` resource fronts |
 | infra.cloudfront.restrictToOffice | bool | `true` | Set to `false` to allow access to the `CloudFrontSite` outside of the office IPs. (managed outside of app-chart) |
-| infra.cloudfront.edgeAllowlist | string | `""` | Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `infra.cloudfront.restrictToOffice`. (managed outside of app-chart) |
 | infra.cloudfront.originHeaderAuth | bool | `true` | Set to 'true' to enable authentication between CloudFront and the origin |
 | infra.cloudfront.defaultCacheBehavior.allowedMethods | string | `"read"` | Whether `read` or `all` HTTP methods are allowed by the `CloudFrontSite` |
 | infra.cloudfront.defaultCacheBehavior.minTtl | int | `0` | The minimum time-to-live for the `CloudFrontSite` cache objects |

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -381,9 +381,6 @@ infra:
     # infra.cloudfront.restrictToOffice -- Set to `false` to allow access to the `CloudFrontSite` outside of the office IPs. (managed outside of app-chart)
     # @section -- infra
     restrictToOffice: true
-    # infra.cloudfront.edgeAllowlist -- Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `infra.cloudfront.restrictToOffice`. (managed outside of app-chart)
-    # @section -- infra
-    edgeAllowlist: ""
     # infra.cloudfront.originHeaderAuth -- Set to 'true' to enable authentication between CloudFront and the origin
     # @section -- infra
     originHeaderAuth: true

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -51,7 +51,6 @@ helm install infra helm-charts/infra
 | cloudfront.domainName | string | `""` | The presentation domain name for the `CloudFrontSite` resource |
 | cloudfront.targetOriginDomainName | string | `.Values.global.ingress.host` | The target origin domain name that the `CloudFrontSite` resource fronts |
 | cloudfront.restrictToOffice | bool | `true` | Set to `true` to restrict access to the `CloudFrontSite` to the office IP ranges |
-| cloudfront.edgeAllowlist | string | unset | Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `cloudfront.restrictToOffice`. Leave unset to keep using `restrictToOffice`. |
 | cloudfront.wildcard | bool | `false` | Allows for requests to domain name with wildcard *.domainName |
 | cloudfront.geoRestriction.restrictionType | string | `"none"` | Whether to `allow` or `deny` the configured locations access to the `CloudFrontSite`. Set to `none` to remove all restrictions |
 | cloudfront.geoRestriction.locations | list | `[]` | A list of ISO ALPHA-2 country codes to apply restrictions to |

--- a/charts/infra/templates/cloudfrontsite.yaml
+++ b/charts/infra/templates/cloudfrontsite.yaml
@@ -19,7 +19,4 @@ spec:
     grpcEnabled: {{ .Values.cloudfront.defaultCacheBehavior.grpcEnabled }}
     {{- end }}
   restrictToOffice: {{ .Values.cloudfront.restrictToOffice | quote}}
-  {{- with .Values.cloudfront.edgeAllowlist }}
-  edgeAllowlist: {{ . | quote }}
-  {{- end }}
 {{- end -}}

--- a/charts/infra/tests/cloudfrontsite_test.yaml
+++ b/charts/infra/tests/cloudfrontsite_test.yaml
@@ -81,46 +81,6 @@ tests:
               allowlistedNames:
                 - my-query-string
 
-  - it: should emit edgeAllowlist when set and still emit restrictToOffice
-    set:
-      global:
-        ingress:
-          host: example.com
-      cloudfront:
-        enabled: true
-        restrictToOffice: true
-        edgeAllowlist: office-auth0
-        domainName: cloudfront.example.com
-        hostedZoneId: ZABCDEFGHIJKL
-        defaultCacheBehavior:
-          allowedMethods: all
-    asserts:
-      - equal:
-          path: spec.edgeAllowlist
-          value: office-auth0
-      - equal:
-          path: spec.restrictToOffice
-          value: "true"
-
-  - it: should NOT emit edgeAllowlist when unset (back-compat)
-    set:
-      global:
-        ingress:
-          host: example.com
-      cloudfront:
-        enabled: true
-        restrictToOffice: true
-        domainName: cloudfront.example.com
-        hostedZoneId: ZABCDEFGHIJKL
-        defaultCacheBehavior:
-          allowedMethods: all
-    asserts:
-      - notExists:
-          path: spec.edgeAllowlist
-      - equal:
-          path: spec.restrictToOffice
-          value: "true"
-
   - it: should create a CloudFrontSite with gRPC enabled
     set:
       cloudfront:

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -104,11 +104,6 @@ cloudfront:
   # @section -- cloudfront
   restrictToOffice: true
 
-  # cloudfront.edgeAllowlist -- Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `cloudfront.restrictToOffice`. Leave unset to keep using `restrictToOffice`.
-  # @default -- unset
-  # @section -- cloudfront
-  edgeAllowlist: ""
-
   # cloudfront.wildcard -- Allows for requests to domain name with wildcard *.domainName
   # @section -- cloudfront
   wildcard: false


### PR DESCRIPTION
Reverts #31.

## Why
#31 was merged without the planned Chart.yaml version bumps (infra 0.26→0.27, app 0.46.1→0.47). Because the release pipeline's chart-releaser runs with `CR_SKIP_EXISTING=true`, no new GitHub release was cut — but the OCI push step **overwrote the already-published `infra:0.26.0` and `app:0.46.1`** artifacts in `ghcr.io/portswigger-apps/charts` with the new `edgeAllowlist` code. We want those published versions to match what they originally shipped.

This revert restores `main` to the pre-#31 content at the **same** versions (0.26.0 / 0.46.1), so re-running the release pipeline re-packages and re-pushes clean artifacts over the contaminated ones.

## ⚠️ Requires TWO pipeline runs to fully restore
The release step packages alphabetically (`app` before `infra`) and `app` vendors `infra` via `helm dependency update` from OCI:
1. **Run 1** restores `infra:0.26.0` cleanly, but `app:0.46.1` still bundles the contaminated `infra` subchart (pulled before infra was re-pushed in the same run).
2. **Run 2** re-packages `app` against the now-clean `infra:0.26.0` → `app:0.46.1` fully clean.

So: merge → let the pipeline run → re-run the workflow once more.

## Going forward
`edgeAllowlist` will be re-introduced as **new** versions (infra 0.27.0, then app 0.47.0) — infra first so app's OCI dependency resolves — rather than mutating already-released versions.

Refs PLAT-450.