### PR TITLE
feat(infra): edgeAllowlist edge WAF posture, bump to 0.27.0 (PLAT-450)

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common infrastructure
 
 type: application
 
-version: 0.26.0
+version: 0.27.0
 
-appVersion: 0.26.0
+appVersion: 0.27.0
 
 keywords:
   - infra

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -51,6 +51,7 @@ helm install infra helm-charts/infra
 | cloudfront.domainName | string | `""` | The presentation domain name for the `CloudFrontSite` resource |
 | cloudfront.targetOriginDomainName | string | `.Values.global.ingress.host` | The target origin domain name that the `CloudFrontSite` resource fronts |
 | cloudfront.restrictToOffice | bool | `true` | Set to `true` to restrict access to the `CloudFrontSite` to the office IP ranges |
+| cloudfront.edgeAllowlist | string | unset | Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `cloudfront.restrictToOffice`. Leave unset to keep using `restrictToOffice`. |
 | cloudfront.wildcard | bool | `false` | Allows for requests to domain name with wildcard *.domainName |
 | cloudfront.geoRestriction.restrictionType | string | `"none"` | Whether to `allow` or `deny` the configured locations access to the `CloudFrontSite`. Set to `none` to remove all restrictions |
 | cloudfront.geoRestriction.locations | list | `[]` | A list of ISO ALPHA-2 country codes to apply restrictions to |

--- a/charts/infra/templates/cloudfrontsite.yaml
+++ b/charts/infra/templates/cloudfrontsite.yaml
@@ -19,4 +19,7 @@ spec:
     grpcEnabled: {{ .Values.cloudfront.defaultCacheBehavior.grpcEnabled }}
     {{- end }}
   restrictToOffice: {{ .Values.cloudfront.restrictToOffice | quote}}
+  {{- with .Values.cloudfront.edgeAllowlist }}
+  edgeAllowlist: {{ . | quote }}
+  {{- end }}
 {{- end -}}

--- a/charts/infra/tests/cloudfrontsite_test.yaml
+++ b/charts/infra/tests/cloudfrontsite_test.yaml
@@ -81,6 +81,46 @@ tests:
               allowlistedNames:
                 - my-query-string
 
+  - it: should emit edgeAllowlist when set and still emit restrictToOffice
+    set:
+      global:
+        ingress:
+          host: example.com
+      cloudfront:
+        enabled: true
+        restrictToOffice: true
+        edgeAllowlist: office-auth0
+        domainName: cloudfront.example.com
+        hostedZoneId: ZABCDEFGHIJKL
+        defaultCacheBehavior:
+          allowedMethods: all
+    asserts:
+      - equal:
+          path: spec.edgeAllowlist
+          value: office-auth0
+      - equal:
+          path: spec.restrictToOffice
+          value: "true"
+
+  - it: should NOT emit edgeAllowlist when unset (back-compat)
+    set:
+      global:
+        ingress:
+          host: example.com
+      cloudfront:
+        enabled: true
+        restrictToOffice: true
+        domainName: cloudfront.example.com
+        hostedZoneId: ZABCDEFGHIJKL
+        defaultCacheBehavior:
+          allowedMethods: all
+    asserts:
+      - notExists:
+          path: spec.edgeAllowlist
+      - equal:
+          path: spec.restrictToOffice
+          value: "true"
+
   - it: should create a CloudFrontSite with gRPC enabled
     set:
       cloudfront:

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -104,6 +104,11 @@ cloudfront:
   # @section -- cloudfront
   restrictToOffice: true
 
+  # cloudfront.edgeAllowlist -- Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `cloudfront.restrictToOffice`. Leave unset to keep using `restrictToOffice`.
+  # @default -- unset
+  # @section -- cloudfront
+  edgeAllowlist: ""
+
   # cloudfront.wildcard -- Allows for requests to domain name with wildcard *.domainName
   # @section -- cloudfront
   wildcard: false


### PR DESCRIPTION
**PR 1 of 2** re-introducing the `edgeAllowlist` feature (originally #31, reverted in #32 to restore the OCI artifacts #31 had overwritten without a version bump).

Adds the `edgeAllowlist` (`public|office|office-auth0`) passthrough to the **infra** chart — `cloudfrontsite.yaml` emits `spec.edgeAllowlist` onto the CloudFrontSite claim only when set, so existing `restrictToOffice`-only apps are unchanged — **and bumps `infra` 0.26.0 → 0.27.0** (the bump #31 omitted).

### Merge order (important)
Merge/release **this first**. The app chart bump (PR 2: app 0.47.0, infra dep → 0.27.0) depends on `infra:0.27.0` already being published to `oci://ghcr.io/portswigger-apps/charts`, because the release pipeline resolves the dependency from OCI at package time. Merging app before infra 0.27.0 is published would fail its `helm dependency update`.

Refs PLAT-450.