### PR TITLE
feat(app): edgeAllowlist passthrough, bump to 0.47.0 (infra dep 0.27.0) (PLAT-450)

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common application patterns
 
 type: application
 
-version: 0.46.1
+version: 0.47.0
 
-appVersion: 0.46.1
+appVersion: 0.47.0
 
 keywords:
   - app
@@ -14,5 +14,5 @@ keywords:
 
 dependencies:
   - name: infra
-    version: 0.26.0
+    version: 0.27.0
     repository: oci://ghcr.io/portswigger-apps/charts

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -108,6 +108,7 @@ helm install app helm-charts/app
 | infra.cloudfront.domainName | string | `""` | The presentation domain name for the `CloudFrontSite` resource |
 | infra.cloudfront.targetOriginDomainName | string | `.Values.global.ingress.host` | The target origin domain name that the `CloudFrontSite` resource fronts |
 | infra.cloudfront.restrictToOffice | bool | `true` | Set to `false` to allow access to the `CloudFrontSite` outside of the office IPs. (managed outside of app-chart) |
+| infra.cloudfront.edgeAllowlist | string | `""` | Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `infra.cloudfront.restrictToOffice`. (managed outside of app-chart) |
 | infra.cloudfront.originHeaderAuth | bool | `true` | Set to 'true' to enable authentication between CloudFront and the origin |
 | infra.cloudfront.defaultCacheBehavior.allowedMethods | string | `"read"` | Whether `read` or `all` HTTP methods are allowed by the `CloudFrontSite` |
 | infra.cloudfront.defaultCacheBehavior.minTtl | int | `0` | The minimum time-to-live for the `CloudFrontSite` cache objects |

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -381,6 +381,9 @@ infra:
     # infra.cloudfront.restrictToOffice -- Set to `false` to allow access to the `CloudFrontSite` outside of the office IPs. (managed outside of app-chart)
     # @section -- infra
     restrictToOffice: true
+    # infra.cloudfront.edgeAllowlist -- Named edge WAF posture (`public`|`office`|`office-auth0`). When set, supersedes `infra.cloudfront.restrictToOffice`. (managed outside of app-chart)
+    # @section -- infra
+    edgeAllowlist: ""
     # infra.cloudfront.originHeaderAuth -- Set to 'true' to enable authentication between CloudFront and the origin
     # @section -- infra
     originHeaderAuth: true


### PR DESCRIPTION
**PR 2 of 2** re-introducing the `edgeAllowlist` feature (originally #31, reverted in #32).

Adds the `edgeAllowlist` passthrough to the **app** chart and bumps **app 0.46.1 → 0.47.0** with its **infra dependency 0.26.0 → 0.27.0**.

### ⚠️ Merge AFTER #33 is released
This depends on `infra:0.27.0` being published to `oci://ghcr.io/portswigger-apps/charts`. The release pipeline runs `helm dependency update charts/app` (packaging `app` before `infra` in the same run), so infra 0.27.0 must already exist in OCI from #33's release. Merging this before #33 is released will fail the release run's dependency resolution.

Depends on #33.

Refs PLAT-450.