### PR TITLE
feat(app): add terminationGracePeriodSeconds override, bump to 0.49.0 (BAE-1543)

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common application patterns
 
 type: application
 
-version: 0.48.0
+version: 0.49.0
 
-appVersion: 0.48.0
+appVersion: 0.49.0
 
 keywords:
   - app

--- a/charts/app/templates/_helpers.tpl
+++ b/charts/app/templates/_helpers.tpl
@@ -330,10 +330,16 @@ opensearch env variables
 {{- end -}}
 
 {{/*
-Calculate termination grace period seconds based on termination delay configuration
+Calculate termination grace period seconds.
+An explicit `deployment.terminationGracePeriodSeconds` always wins (lets a workload
+drain long-lived work independently of the preStop delay). Otherwise fall back to the
+historical `30 + terminationDelay.delaySeconds` (or a bare 30 when no delay is set), so
+charts that do not set the override render byte-identically.
 */}}
 {{- define "app.terminationGracePeriodSeconds" -}}
-{{- if and .Values.deployment.terminationDelay .Values.deployment.terminationDelay.enabled -}}
+{{- if .Values.deployment.terminationGracePeriodSeconds -}}
+{{- .Values.deployment.terminationGracePeriodSeconds -}}
+{{- else if and .Values.deployment.terminationDelay .Values.deployment.terminationDelay.enabled -}}
 {{- add 30 .Values.deployment.terminationDelay.delaySeconds -}}
 {{- else -}}
 30

--- a/charts/app/tests/kubernetes_deployment_test.yaml
+++ b/charts/app/tests/kubernetes_deployment_test.yaml
@@ -919,6 +919,38 @@ tests:
             - sleep
             - "15"
 
+  - it: should use explicit terminationGracePeriodSeconds override when set
+    template: kubernetes/deployment.yaml
+    set:
+      deployment:
+        terminationGracePeriodSeconds: 330
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 330
+      # No preStop hook when terminationDelay stays disabled (the default).
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].lifecycle
+
+  - it: should let explicit terminationGracePeriodSeconds override the terminationDelay calculation
+    template: kubernetes/deployment.yaml
+    set:
+      deployment:
+        terminationGracePeriodSeconds: 330
+        terminationDelay:
+          enabled: true
+          delaySeconds: 15
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 330
+      # preStop still renders from terminationDelay; only the grace period is overridden.
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].lifecycle.preStop.exec.command
+          value:
+            - sleep
+            - "15"
+
   - it: should not enable NATS by default
     template: kubernetes/deployment.yaml
     asserts:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -130,6 +130,13 @@ deployment:
   #     target:
   #       type: AverageValue
   #       averageValue: "160"
+  # deployment.terminationGracePeriodSeconds -- (int) Explicit pod terminationGracePeriodSeconds.
+  # When set, it overrides the value derived from `terminationDelay` — use it to give a workload
+  # a long graceful-drain window without inflating the preStop sleep. Leave unset to keep the
+  # historical `30 + terminationDelay.delaySeconds` behaviour.
+  # @default -- `30 + terminationDelay.delaySeconds`
+  # @section -- application
+  terminationGracePeriodSeconds: null
   terminationDelay:
     # @ignored
     # deployment.terminationDelay.enabled -- Set to `true` to add a sleeping preStop hook.


### PR DESCRIPTION
## What

Adds an optional `deployment.terminationGracePeriodSeconds` to the `app` chart. When set it overrides the pod's grace period directly; when unset, behaviour is unchanged — it falls back to the historical `30 + deployment.terminationDelay.delaySeconds` (or a bare `30`).

Bumps the chart `0.48.0 → 0.49.0`.

## Why

Today the grace period is *coupled* to the preStop sleep: `terminationGracePeriodSeconds = 30 + terminationDelay.delaySeconds`, and SIGTERM fires at `t = delaySeconds`. That hardwires the post-SIGTERM drain window to exactly 30s — there's no way to give a workload a long graceful-drain window without also inflating the preStop sleep (which just keeps a doomed pod taking new work for longer).

`hakawai-agent` needs a ~5-minute window so an in-flight LLM turn can finish before SIGKILL during rollouts / scale-down (BAE-1543). This override decouples the two: set a long grace period while keeping (or disabling) the preStop hook independently.

## Backward compatibility

Purely additive, gated behind a new opt-in key defaulting to `null`. Any chart that doesn't set `terminationGracePeriodSeconds` renders **byte-identically** to before. Verified with `helm template` across all four combinations:

| `terminationGracePeriodSeconds` | `terminationDelay` | grace | preStop |
|---|---|---|---|
| unset | disabled | 30 | absent |
| unset | enabled (15) | 45 | sleep 15 |
| 330 | disabled | 330 | absent |
| 330 | enabled (15) | 330 | sleep 15 |

## Tests

- Added two `helm unittest` cases in `kubernetes_deployment_test.yaml` (override alone; override + `terminationDelay`).
- `helm lint` clean.

## Consumer

`hakawai-agent` (separate repo) will set `terminationGracePeriodSeconds: 330` and disable `terminationDelay` to drain in-flight turns on rollout — the motivating use case for this knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
