### PR TITLE
fix(app): opt-out flag for hook envFrom secretEnv bootstrap ordering

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common application patterns
 
 type: application
 
-version: 0.49.0
+version: 0.50.0
 
-appVersion: 0.49.0
+appVersion: 0.50.0
 
 keywords:
   - app

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -157,6 +157,7 @@ helm install app helm-charts/app
 | extraDeploy | list | `[]` | Extra Kubernetes configuration |
 | preDeployCommand | string[] | `[]` | Command to run before install and upgrade of your application. See examples in values.yaml |
 | preRollbackCommand | string[] | `[]` | Command to run before a rollback. See examples in values.yaml |
+| hookSecretEnv | bool | `true` | Whether `preDeployCommand`/`preRollbackCommand` hook pods inherit `secretEnv`. Defaults to `true` to match prior behaviour. Set to `false` if this is the first release introducing `secretEnv` on a chart that also sets `preDeployCommand`/`preRollbackCommand`: `pre-install`/`pre-upgrade`/`pre-rollback` hooks run before the release's own `secretEnv` Secret is created, so a hook that requires it will fail with "secret ... not found" on that first introduction. Once the Secret exists, it's safe to flip back to `true`. |
 
 ---
 

--- a/charts/app/templates/helm/_hookpodtemplate.tpl
+++ b/charts/app/templates/helm/_hookpodtemplate.tpl
@@ -53,12 +53,13 @@ Outputs a pod spec for use in helm hooks.
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}
-        {{- if or .Values.envFrom .Values.secretEnv }}
+        {{- $includeSecretEnv := and .Values.secretEnv .Values.hookSecretEnv }}
+        {{- if or .Values.envFrom $includeSecretEnv }}
         envFrom:
           {{- with .Values.envFrom }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- if .Values.secretEnv }}
+          {{- if $includeSecretEnv }}
           - secretRef:
               name: {{ .Release.Name }}-env
           {{- end }}

--- a/charts/app/tests/helm_pre_deploy_hook_test.yaml
+++ b/charts/app/tests/helm_pre_deploy_hook_test.yaml
@@ -200,3 +200,41 @@ tests:
           content:
             name: REDIS_READER_URL
             value: rediss://$(REDIS_USERNAME):$(REDIS_PASSWORD)@$(REDIS_READER_HOST):$(REDIS_READER_PORT)
+
+  - it: should include secretEnv in envFrom by default
+    set:
+      preDeployCommand: ["python3"]
+      secretEnv:
+        SOME_SECRET: some-value
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-env
+
+  - it: should exclude secretEnv from envFrom when hookSecretEnv is false
+    # Covers the bootstrap-ordering case: pre-install/pre-upgrade/pre-rollback hooks run
+    # before the release's own secretEnv Secret is created, so a hook that requires it
+    # fails with "secret ... not found" the first time secretEnv is introduced.
+    set:
+      preDeployCommand: ["python3"]
+      secretEnv:
+        SOME_SECRET: some-value
+      hookSecretEnv: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-env
+
+  - it: should omit envFrom entirely when only secretEnv is set and hookSecretEnv is false
+    set:
+      preDeployCommand: ["python3"]
+      secretEnv:
+        SOME_SECRET: some-value
+      hookSecretEnv: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].envFrom

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -536,3 +536,13 @@ preRollbackCommand: []
 # - python
 # - manage.py
 # - rollback
+
+# hookSecretEnv -- Whether `preDeployCommand`/`preRollbackCommand` hook pods inherit `secretEnv`.
+# Defaults to `true` to match prior behaviour. Set to `false` if this is the first release
+# introducing `secretEnv` on a chart that also sets `preDeployCommand`/`preRollbackCommand`:
+# `pre-install`/`pre-upgrade`/`pre-rollback` hooks run *before* the release's own `secretEnv`
+# Secret is created, so a hook that requires it will fail with "secret ... not found" on that
+# first introduction. Once the Secret exists (e.g. after one release with this set to `false`),
+# it's safe to flip back to `true`.
+# @section -- application
+hookSecretEnv: true


### PR DESCRIPTION
## Summary
- `preDeployCommand`/`preRollbackCommand` hook pods (`templates/helm/_hookpodtemplate.tpl`) unconditionally inherit `secretEnv` via `envFrom`. Helm's `pre-install`/`pre-upgrade`/`pre-rollback` hooks run **before** the release's own manifests (including the `secretEnv` Secret) are applied — so the very first time a chart combining `preDeployCommand`/`preRollbackCommand` with `secretEnv` introduces `secretEnv`, the hook fails: `Error: secret "<release>-env" not found` → `CreateContainerConfigError` → hook never completes → atomic rollback.
- Hit this rolling out `secretEnv` on `cod-session-viewer` (has a DB-migration `preDeployCommand`). Every other current consumer of `secretEnv` has no `preDeployCommand`/`preRollbackCommand`, so nothing else has hit this — but any product combining both would.
- Adds `hookSecretEnv` (default `true`, preserves current behaviour for every existing chart consumer) so a first-time `secretEnv` rollout on a chart with a hook can set it `false` for one release to break the bootstrap cycle, then flip back to `true` once the Secret exists.

## Test plan
- [x] `helm lint charts/app/` passes
- [x] Manually rendered `templates/helm/pre-deploy-hook.yaml` via `helm template` for both `hookSecretEnv` unset (default) and `hookSecretEnv=false` — confirmed `envFrom`/`secretRef` is present by default (unchanged) and omitted entirely when set to `false`
- [x] Added `helm-unittest` cases to `charts/app/tests/helm_pre_deploy_hook_test.yaml` covering both states (shared `_hookpodtemplate.tpl`, so `pre-rollback-hook.yaml` is covered by the same template logic per the existing "common functionality tested in PreDeployHook tests" convention in `helm_pre_rollback_hook_test.yaml`)
- [ ] CI `helm unittest --strict charts/*/`