### PR TITLE
docs(app): collapse hookSecretEnv values.yaml comment to one line

### DIFF
--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -537,12 +537,6 @@ preRollbackCommand: []
 # - manage.py
 # - rollback
 
-# hookSecretEnv -- Whether `preDeployCommand`/`preRollbackCommand` hook pods inherit `secretEnv`.
-# Defaults to `true` to match prior behaviour. Set to `false` if this is the first release
-# introducing `secretEnv` on a chart that also sets `preDeployCommand`/`preRollbackCommand`:
-# `pre-install`/`pre-upgrade`/`pre-rollback` hooks run *before* the release's own `secretEnv`
-# Secret is created, so a hook that requires it will fail with "secret ... not found" on that
-# first introduction. Once the Secret exists (e.g. after one release with this set to `false`),
-# it's safe to flip back to `true`.
+# hookSecretEnv -- Whether `preDeployCommand`/`preRollbackCommand` hooks inherit `secretEnv`. Defaults to `true`; set `false` for one release to break the bootstrap ordering race when first introducing `secretEnv` on a chart with these hooks (see README).
 # @section -- application
 hookSecretEnv: true


### PR DESCRIPTION
## Summary
Follow-up to #37 — the `hookSecretEnv` values.yaml comment was a 6-line block, the only multi-line field comment in the file. Every other field (even long ones, e.g. `initContainers` at 196 chars) is a single physical line, with the full human-readable explanation living in the auto-generated README table instead. Collapses it to match.

No functional change — README.md already carries the full explanation in its table row.