### PR TITLE
docs: document pre-commit git hook installation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md — helm-charts
+
+Shared Helm "monocharts" (`app`, `cron`, `infra`) for the platform. Every product
+in the org can depend on these — changes are broad-blast-radius by design.
+
+## Before every commit in this repo
+
+Run `pre-commit run --all-files` (after a one-time `pre-commit install` —
+see README "Getting started"). **This is not enforced by CI or by git itself** —
+it's a local hook, trivially skipped, and nothing currently catches drift on
+merge. Skipping it has landed stale docs for real: the `app` chart's README
+version badge sat wrong across three releases before anyone noticed
+(portswigger-apps/helm-charts#37, #38, #39).
+
+Specifically, `helm-docs` regenerates each chart's README from its
+`values.yaml` comments (`# key -- description`, `@section` tags), using the
+exact invocation in `.pre-commit-config.yaml`:
+
+```
+helm-docs --chart-search-root=charts --template-files=./README.md.gotmpl --sort-values-order=file
+```
+
+**Never hand-edit a chart README, and never run bare `helm-docs` without those
+flags** — the default invocation alphabetizes/reformats and misplaces
+`@section`-tagged fields relative to what's actually committed.
+
+## Versioning
+
+Bump `version` (and usually `appVersion`) in the chart's own `Chart.yaml` for
+every user-visible change. `chart-releaser` only publishes a new release when
+the version changes (`CR_SKIP_EXISTING: true` in `.github/workflows/test-and-release.yaml`
+silently no-ops otherwise) — a change with no version bump never reaches
+consumers, however correct the diff.
+
+## Testing
+
+- `helm lint charts/<chart>/`
+- `helm unittest --strict charts/*/` — needs the `helm-unittest` plugin
+  (`helm plugin install https://github.com/helm-unittest/helm-unittest`), not
+  installed by default.
+
+Both run in CI (`.github/workflows/test-and-release.yaml`) on every PR; neither
+substitutes for `pre-commit` — they don't check README freshness at all.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,22 @@ You'll need the following installed:
  - Helm unittest plugin: https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#install
  - pre-commit: https://pre-commit.com/#install
 
+Then, from the repo root, install the git hook so it runs automatically on every commit:
+
+```sh
+pre-commit install
+```
+
+Without this step `pre-commit` is just a config file — nothing runs it, and README drift
+(stale version badges, missing/misplaced values) won't be caught until someone notices by eye.
+CI does not currently run `pre-commit` either, so this is the only thing standing between a
+values.yaml change and a stale README.
+
 ## Documentation
 
-We use `helm-docs` installed as a pre-commit hook to regenerate READMEs with Helm chart
-values in a table.
+We use `helm-docs`, run via the `pre-commit` git hook installed above, to regenerate READMEs
+with Helm chart values in a table. Run `pre-commit run --all-files` to regenerate on demand
+(e.g. if you skipped installing the hook, or amended a commit with `--no-verify`).
 
 ## Unit tests
 


### PR DESCRIPTION
## Summary
Follow-up to the platform review on #37/#39. `pre-commit` was listed under "You'll need the following installed" but nothing told contributors to actually run `pre-commit install` — the config file (`.pre-commit-config.yaml`) does nothing on its own; it only becomes a real git hook once installed. CI doesn't run `pre-commit` either, so there was no safety net at all. That's how the `app` chart's README version badge went three releases (`0.47.0`/`0.48.0`/`0.49.0`) without being regenerated before anyone noticed.

Adds:
- an explicit `pre-commit install` step to "Getting started"
- a note that CI does *not* enforce this, so the hook is the only thing catching README drift
- a `pre-commit run --all-files` pointer for regenerating on demand (e.g. after a `--no-verify` commit)

Deliberately scoped to docs only — the actual stale chart READMEs are #39, kept separate to avoid overlapping PRs.

## Out of scope (flagging for a separate discussion, not doing here)
Wiring `pre-commit run --all-files` into CI as a real gate would close the loop further (right now even with this doc, a contributor can still skip the hook or use `--no-verify` and CI won't catch it). Happy to raise that as its own PR if useful.