### PR TITLE
ci: run pre-commit (helm-docs) as part of test-and-release

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -28,6 +28,33 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      # helm-docs' pre-commit hook shells out to a pre-installed binary rather
+      # than building its own (unlike the other two hooks below) — install it
+      # here, pinned from .pre-commit-config.yaml's own `rev` so the two can't
+      # drift apart.
+      - name: Install helm-docs
+        run: |
+          set -euo pipefail
+          VERSION=$(awk '/norwoodj\/helm-docs/{found=1} found && /rev:/{print $2; exit}' .pre-commit-config.yaml)
+          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/${VERSION}/helm-docs_${VERSION#v}_Linux_x86_64.tar.gz" \
+            | tar xz -C /usr/local/bin helm-docs
+          helm-docs --version
+
+      # Runs the same hooks as `pre-commit install` locally (see CLAUDE.md /
+      # README "Getting started") — chiefly helm-docs, which regenerates each
+      # chart's README from values.yaml. Nothing enforced this before: a
+      # contributor who skipped `pre-commit install` (or used --no-verify)
+      # could merge a stale README with only human review to catch it, which
+      # is exactly how the app chart's version badge drifted across three
+      # releases (#37, #38, #39).
+      - name: Pre-commit
+        uses: pre-commit/action@v3.0.1
+
       - name: Setup Helmfile
         uses: mamezou-tech/setup-helmfile@v2.1.0
         with:


### PR DESCRIPTION
## Summary
Follow-up to platform's review comments on #37/#39 ("readme's are missing the chart updates" / "pre commit hasn't been run"). Nothing currently enforces README freshness on merge: `helm lint`/`helm unittest` don't check it, and `pre-commit` itself only runs if a contributor remembered to `pre-commit install` locally (and didn't use `--no-verify`). That gap is how the `app` chart's README version badge went stale across three releases (#37, #38, #39) before anyone noticed by eye.

Adds a `Pre-commit` step to the `test-and-release` job, so the CI check fails if any pre-commit hook (chiefly `helm-docs`) would modify a file — i.e. the committed README no longer matches `values.yaml`/`Chart.yaml`.

## Important caveat — this alone doesn't block merges yet
I checked this repo's `main` protection and it's configured as a **repository ruleset**, not classic branch protection. Querying it directly, the ruleset currently requires only:
```
required_approving_review_count: 1, require_code_owner_review: true
```
**No status checks are required at all** — not this new one, not even the existing `helm lint`/`helm unittest`. So this PR makes the check exist and report, but a PR can still merge if it fails, same as today.

Making it actually block merges needs a "require status checks to pass" rule added to the ruleset, naming this job. That requires repo admin — I only have `push`/`triage`, so I can't make that change myself. Raising it with platform separately.

## Test plan
- [ ] CI passes with the new step included
- [ ] Manually verify: introduce a deliberate README/values.yaml mismatch on a throwaway branch and confirm the `Pre-commit` step fails