### PR TITLE
fix(app): use native preStop sleep action so drain works on distroless images

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common application patterns
 
 type: application
 
-version: 0.50.0
+version: 0.50.1
 
-appVersion: 0.50.0
+appVersion: 0.50.1
 
 keywords:
   - app

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.50.0](https://img.shields.io/badge/Version-0.50.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.0](https://img.shields.io/badge/AppVersion-0.50.0-informational?style=flat-square)
+![Version: 0.50.1](https://img.shields.io/badge/Version-0.50.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.1](https://img.shields.io/badge/AppVersion-0.50.1-informational?style=flat-square)
 
 A Helm "monochart" for deploying common application patterns
 

--- a/charts/app/templates/kubernetes/_podtemplate.tpl
+++ b/charts/app/templates/kubernetes/_podtemplate.tpl
@@ -53,10 +53,11 @@ Outputs a pod spec for use in different resources.
         {{- if .Values.deployment.terminationDelay.enabled }}
         lifecycle:
           preStop:
-            exec:
-              command:
-              - sleep
-              - {{ .Values.deployment.terminationDelay.delaySeconds | quote }}
+            # Native SleepAction (k8s >=1.30): runs in the kubelet, so it works on
+            # distroless images that have no `sleep` binary. An exec `sleep` hook
+            # silently fails there (FailedPreStopHook), skipping the drain window.
+            sleep:
+              seconds: {{ .Values.deployment.terminationDelay.delaySeconds }}
         {{- end }}
         resources:
           requests:

--- a/charts/app/tests/kubernetes_deployment_test.yaml
+++ b/charts/app/tests/kubernetes_deployment_test.yaml
@@ -914,10 +914,8 @@ tests:
           path: spec.template.spec.terminationGracePeriodSeconds
           value: 45
       - equal:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].lifecycle.preStop.exec.command
-          value:
-            - sleep
-            - "15"
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].lifecycle.preStop.sleep.seconds
+          value: 15
 
   - it: should use explicit terminationGracePeriodSeconds override when set
     template: kubernetes/deployment.yaml
@@ -946,10 +944,8 @@ tests:
           value: 330
       # preStop still renders from terminationDelay; only the grace period is overridden.
       - equal:
-          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].lifecycle.preStop.exec.command
-          value:
-            - sleep
-            - "15"
+          path: spec.template.spec.containers[?(@.name == "RELEASE-NAME")].lifecycle.preStop.sleep.seconds
+          value: 15
 
   - it: should not enable NATS by default
     template: kubernetes/deployment.yaml


### PR DESCRIPTION
## Problem

`deployment.terminationDelay` renders the graceful-shutdown drain as an **exec** preStop hook:

```yaml
lifecycle:
  preStop:
    exec:
      command: ["sleep", "<delaySeconds>"]
```

That requires a `sleep` binary in the container. **Distroless images have no shell and no coreutils**, so the hook fails on *every* pod termination (`FailedPreStopHook`), the intended "de-register before SIGTERM" window never opens, and pods take SIGTERM while the Service/ingress is still routing to them — dropped requests during every rollout.

This was found from a Burp AI black-screen-during-rollout report: `hakawai-burpai-api` (distroless `portswigger/dhi-eclipse-temurin`) hits `FailedPreStopHook` on every termination, and prod Loki shows requests served with a `200` in the same second the pod is torn down (zero drain gap).

### Blast radius

An org sweep found **≥10 services** that enable `terminationDelay` on a distroless base and are therefore silently affected — across `hakawai-*`, `auth-*`, and `bifrost-*`. Both distroless families are hit: `portswigger/dhi-*` **and** `gcr.io/distroless/base-debian12` (neither ships `sleep`). Services on Debian/Alpine/`*-slim` images are unaffected. Fixing it here repairs all of them at once, with no per-service change.

## Fix

Use the native Kubernetes `SleepAction`. The kubelet performs the sleep, so no in-container binary is needed — works identically on distroless and non-distroless images:

```yaml
lifecycle:
  preStop:
    sleep:
      seconds: {{ .Values.deployment.terminationDelay.delaySeconds }}
```

No values-schema change; `delaySeconds` is reused as an integer.

`SleepAction` is **beta and on-by-default since k8s 1.30**, and **GA since 1.32** — all target clusters are on 1.35, so no feature-gate action is needed.

## Verification

- `helm template` with `terminationDelay.enabled=true` now renders `preStop.sleep.seconds`.
- `helm unittest charts/app` — 22 suites / 167 tests pass, including the two `terminationDelay` assertions updated in `tests/kubernetes_deployment_test.yaml` (`preStop.exec.command` → `preStop.sleep.seconds`).
- Validated against a live v1.35 cluster: a pod with `preStop.sleep.seconds` is accepted via server-side dry-run; the currently-deployed exec form reproduces `FailedPreStopHook` on every termination.

## Effect on non-distroless consumers

Behaviourally identical — both forms hold the pod in `Terminating` for `delaySeconds` before SIGTERM; the interaction with `terminationGracePeriodSeconds` is unchanged. Adopting the new chart version rolls pods once (pod-template change) and drops the incidental dependency on an in-image `sleep`. The only regression risk: `preStop.sleep.seconds` must be an integer, so any consumer that set `delaySeconds` as a quoted string would fail validation at deploy (loud, not silent) — all current consumers use a bare integer.
