### PR TITLE
feat(infra): add s3Bucket.replication with versioning guard, bump to 0.28.0 (PLAT-626)

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common infrastructure
 
 type: application
 
-version: 0.27.0
+version: 0.28.0
 
-appVersion: 0.27.0
+appVersion: 0.28.0
 
 keywords:
   - infra

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -41,6 +41,7 @@ helm install infra helm-charts/infra
 | s3Bucket.bucketAccessPolicies | list | `[]` | Additional IAM policy statements to include in the S3 bucket resource policy. KMS key permissions are auto-derived from S3 actions (`s3:PutObject` grants `kms:GenerateDataKey`, `s3:GetObject` grants `kms:Decrypt`). |
 | s3Bucket.versioning | bool | `false` | Set to `true` to enable versioning on the `s3Bucket` |
 | s3Bucket.replication | bool | `false` | Set to `true` to provision a same-account, same-region replica of the `s3Bucket` for operational recovery. Requires `s3Bucket.versioning: true` — S3 replication cannot be enabled on a non-versioned bucket. |
+| s3Bucket.replicationRetentionDays | int | `90` | How long the replica keeps an object version after it stops being current, i.e. counted from the moment the object is overwritten or deleted in the source — **not** from when it was written. Objects still live in the source are never expired, so the replica always holds a copy of live data however old that data is. Ignored unless `s3Bucket.replication` is `true`. |
 | s3Bucket.lifecycleRules | list | `[]` | Configure the `s3Bucket` storage [lifecycle rules](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.2.1/resources/s3.aws.upbound.io/BucketLifecycleConfiguration/v1beta1#doc:spec-forProvider-rule) |
 
 ### cloudfront

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -1,6 +1,6 @@
 # infra
 
-![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.0](https://img.shields.io/badge/AppVersion-0.27.0-informational?style=flat-square)
+![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.28.0](https://img.shields.io/badge/AppVersion-0.28.0-informational?style=flat-square)
 
 A Helm "monochart" for deploying common infrastructure
 
@@ -40,6 +40,7 @@ helm install infra helm-charts/infra
 | s3Bucket.nameOverride | string | `""` | Override the `s3Bucket` name or use with `create: false` to map the secrets of an instance created elsewhere |
 | s3Bucket.bucketAccessPolicies | list | `[]` | Additional IAM policy statements to include in the S3 bucket resource policy. KMS key permissions are auto-derived from S3 actions (`s3:PutObject` grants `kms:GenerateDataKey`, `s3:GetObject` grants `kms:Decrypt`). |
 | s3Bucket.versioning | bool | `false` | Set to `true` to enable versioning on the `s3Bucket` |
+| s3Bucket.replication | bool | `false` | Set to `true` to provision a same-account, same-region replica of the `s3Bucket` for operational recovery. Requires `s3Bucket.versioning: true` — S3 replication cannot be enabled on a non-versioned bucket. |
 | s3Bucket.lifecycleRules | list | `[]` | Configure the `s3Bucket` storage [lifecycle rules](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.2.1/resources/s3.aws.upbound.io/BucketLifecycleConfiguration/v1beta1#doc:spec-forProvider-rule) |
 
 ### cloudfront

--- a/charts/infra/templates/_helpers.tpl
+++ b/charts/infra/templates/_helpers.tpl
@@ -67,6 +67,23 @@ Fetch given field from existing secret or generate a new random value
 
 
 {{/*
+Guards s3Bucket features that AWS only permits on a versioned bucket.
+
+Deliberately named for the general case rather than for any one feature: S3
+Object Lock has the identical `versioning: true` prerequisite and is queued
+(BAE-1538), so extend this helper with another check rather than adding a
+second one.
+
+Each check covers both directions at once — enabling the dependent feature
+without versioning, and removing versioning from a bucket that already has it.
+*/}}
+{{- define "infra.s3Bucket.validateVersioningDependents" -}}
+{{- if and .Values.s3Bucket.replication (not .Values.s3Bucket.versioning) -}}
+{{ fail "s3Bucket.replication requires s3Bucket.versioning: true — S3 replication cannot be enabled on a non-versioned bucket." }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns the managed cache policy id based on policy name
 */}}
 {{- define "infra.cloudfrontRouter.cachePolicyId" -}}

--- a/charts/infra/templates/s3bucket.yaml
+++ b/charts/infra/templates/s3bucket.yaml
@@ -11,6 +11,7 @@ spec:
   irsaRoleName: {{ default ( include "infra.aws.name" . ) .Values.global.serviceAccount.name }}-irsarole
   versioning: {{ .Values.s3Bucket.versioning }}
   replication: {{ .Values.s3Bucket.replication }}
+  replicationRetentionDays: {{ .Values.s3Bucket.replicationRetentionDays }}
   {{- with .Values.s3Bucket.lifecycleRules }}
   lifecycleRules:
   {{- range $i, $rule := . }}

--- a/charts/infra/templates/s3bucket.yaml
+++ b/charts/infra/templates/s3bucket.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.s3Bucket.enabled .Values.s3Bucket.create }}
+{{- include "infra.s3Bucket.validateVersioningDependents" . }}
 
 apiVersion: platform.portswigger.io/v1alpha1
 kind: S3Bucket
@@ -9,6 +10,7 @@ metadata:
 spec:
   irsaRoleName: {{ default ( include "infra.aws.name" . ) .Values.global.serviceAccount.name }}-irsarole
   versioning: {{ .Values.s3Bucket.versioning }}
+  replication: {{ .Values.s3Bucket.replication }}
   {{- with .Values.s3Bucket.lifecycleRules }}
   lifecycleRules:
   {{- range $i, $rule := . }}

--- a/charts/infra/tests/s3bucket_test.yaml
+++ b/charts/infra/tests/s3bucket_test.yaml
@@ -175,6 +175,35 @@ tests:
       - equal:
           path: spec.replication
           value: true
+      - equal:
+          path: spec.replicationRetentionDays
+          value: 90
+
+  - it: should set replicationRetentionDays to 90 by default
+    set:
+      s3Bucket:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.replicationRetentionDays
+          value: 90
+
+  - it: should set replicationRetentionDays when overridden
+    set:
+      s3Bucket:
+        enabled: true
+        versioning: true
+        replication: true
+        replicationRetentionDays: 30
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.replication
+          value: true
+      - equal:
+          path: spec.replicationRetentionDays
+          value: 30
 
   - it: should fail when replication is true and versioning is false
     set:

--- a/charts/infra/tests/s3bucket_test.yaml
+++ b/charts/infra/tests/s3bucket_test.yaml
@@ -151,6 +151,57 @@ tests:
           path: spec.versioning
           value: true
 
+  - it: should set replication to false by default
+    set:
+      s3Bucket:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.replication
+          value: false
+
+  - it: should set replication to true when replication and versioning are true
+    set:
+      s3Bucket:
+        enabled: true
+        versioning: true
+        replication: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.versioning
+          value: true
+      - equal:
+          path: spec.replication
+          value: true
+
+  - it: should fail when replication is true and versioning is false
+    set:
+      s3Bucket:
+        enabled: true
+        versioning: false
+        replication: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "s3Bucket.replication requires s3Bucket.versioning: true — S3 replication cannot be enabled on a non-versioned bucket."
+
+  - it: should still render versioning when versioning is true and replication is false
+    set:
+      s3Bucket:
+        enabled: true
+        versioning: true
+        replication: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.versioning
+          value: true
+      - equal:
+          path: spec.replication
+          value: false
+
   - it: should not set bucketAccessPolicies by default
     set:
       s3Bucket:

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -77,6 +77,10 @@ s3Bucket:
   # @section -- s3Bucket
   replication: false
 
+  # s3Bucket.replicationRetentionDays -- How long the replica keeps an object version after it stops being current, i.e. counted from the moment the object is overwritten or deleted in the source — **not** from when it was written. Objects still live in the source are never expired, so the replica always holds a copy of live data however old that data is. Ignored unless `s3Bucket.replication` is `true`.
+  # @section -- s3Bucket
+  replicationRetentionDays: 90
+
   # s3Bucket.lifecycleRules -- (list) Configure the `s3Bucket` storage [lifecycle rules](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.2.1/resources/s3.aws.upbound.io/BucketLifecycleConfiguration/v1beta1#doc:spec-forProvider-rule)
   # @default -- `[]`
   # @section -- s3Bucket

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -73,6 +73,10 @@ s3Bucket:
   # @section -- s3Bucket
   versioning: false
 
+  # s3Bucket.replication -- Set to `true` to provision a same-account, same-region replica of the `s3Bucket` for operational recovery. Requires `s3Bucket.versioning: true` — S3 replication cannot be enabled on a non-versioned bucket.
+  # @section -- s3Bucket
+  replication: false
+
   # s3Bucket.lifecycleRules -- (list) Configure the `s3Bucket` storage [lifecycle rules](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.2.1/resources/s3.aws.upbound.io/BucketLifecycleConfiguration/v1beta1#doc:spec-forProvider-rule)
   # @default -- `[]`
   # @section -- s3Bucket


### PR DESCRIPTION
## What

Adds two values to the `infra` chart, passed through to the `S3Bucket` claim spec alongside the existing `versioning` field, and bumps `infra` 0.27.0 → 0.28.0 (`version` + `appVersion`):

- **`s3Bucket.replication`** (bool, default `false`) — provisions a same-account, same-region replica bucket
- **`s3Bucket.replicationRetentionDays`** (int, default `90`) — how long the replica keeps a version after it stops being current

This is the chart half of **PLAT-626**; the composition half is portswigger-it/platform#821. The replica is for **operational recovery** — the "someone wrote something wrong and needs to restore it" case — not for cross-region DR.

## The versioning prerequisite, and why there's a guard

**S3 replication cannot be enabled on a non-versioned bucket.** AWS rejects it outright, so `replication: true` with `versioning: false` is never a valid configuration — it can only ever be a mistake, and without a guard it would surface as a confusing Crossplane/AWS-level reconcile failure long after `helm upgrade` reported success.

So the chart makes the invalid combination unrepresentable. `charts/infra/templates/_helpers.tpl` gains:

```
infra.s3Bucket.validateVersioningDependents
```

invoked from `s3bucket.yaml`, which `fail`s the render with an actionable message that states the cause:

```
s3Bucket.replication requires s3Bucket.versioning: true — S3 replication cannot be enabled on a non-versioned bucket.
```

This follows the existing `fail`-based validation precedent in that file (`infra.cloudfrontRouter.cachePolicyId` / `originRequestPolicyId`, which `fail` on unrecognised policy names).

That single check covers **both directions**: setting `replication` without `versioning`, *and* later removing `versioning` from a bucket that already has `replication` — the second being the more dangerous one, since it would otherwise silently break an existing replica.

The helper is **deliberately named for the general versioning-dependent-feature case**, not for replication. S3 Object Lock has the identical `versioning: true` prerequisite and is already queued (**BAE-1538**); the next person should add a second check to this helper rather than write a parallel one. There's a comment in the helper saying so.

## Retention: `replicationRetentionDays`, default 90

The composition now bakes a retention policy into the replica rather than deferring it. The replica has two growth terms — noncurrent versions created by overwrites in the source, and objects deleted in the source. Delete-marker replication is enabled on the composition side, so a source delete makes the replica's copy **noncurrent rather than gone** (the version survives behind the marker and stays recoverable), and the retention clock then reaps it. One number bounds both terms.

**Read the window carefully:** it counts from the moment an object stops being current — i.e. when it is overwritten or deleted in the source — **not** from when it was written. Objects still live in the source only ever have a current version, and nothing expires current versions, so **the replica always holds a copy of live data however old that data is**. A reader who assumes "nothing older than 90 days is kept" would be wrong: a five-year-old object that has never been touched is still replicated and still there.

Retention is emitted unconditionally alongside `replication` to keep the template boring — the XRD defaults it to 90 and ignores it when replication is off. It gets no guard of its own, since it has no versioning dependency; it's simply inert when replication is off.

## This flag is inert until the composition lands

The composition side — destination bucket, replication IAM role, the `BucketReplicationConfiguration`, and now the retention lifecycle rule — lands **separately in `portswigger-it/platform`** (#821). Until that merges, setting `replication: true` just puts unconsumed fields on the claim spec: no replica is created. Nothing here changes behaviour for any existing consumer, since replication defaults to `false`.

## Follow-up: the `app` chart bump is intentionally a separate PR

The `app` chart pins `infra` by version, so consumers (e.g. hakawai-agent) can't reach this until `app`'s `dependencies[infra].version` is bumped to 0.28.0.

That bump has to **follow** this PR rather than ride along with it: `infra` 0.28.0 doesn't exist in `oci://ghcr.io/portswigger-apps/charts` until `chart-releaser` publishes it on merge here, so `helm dependency update charts/app/` can't resolve it yet (it 401s / can't find the tag), and `charts/app/Chart.lock` can't be honestly regenerated. A follow-up PR will bump `app` 0.50.1 → 0.51.0 with the dep at 0.28.0 and a properly regenerated lock.

Worth flagging while we're here: **`charts/app/Chart.lock` is already stale on `main`** — it pins `infra` 0.22.7 via the old `https://portswigger-apps.github.io/helm-charts/` repo, while `Chart.yaml` says 0.27.0 via `oci://`. Its digest matches the old 0.22.7/https spec, so it hasn't been regenerated since the move to OCI. The follow-up PR is the natural place to fix that.

## Testing

`charts/infra/tests/s3bucket_test.yaml` gains cases in the suite's existing style:

- `replication` is `false` by default
- `replication: true` + `versioning: true` renders `replication: true` **and** `replicationRetentionDays: 90`
- `replication: true` + `versioning: false` **fails**, asserting the exact message via `failedTemplate`
- `versioning: true` + `replication: false` still renders correctly (no regression)
- `replicationRetentionDays` is `90` by default
- an explicit `replicationRetentionDays: 30` renders through

The `failedTemplate` case was verified non-vacuous: corrupting the expected message makes the test fail with the real message as `Actual`, confirming the guard genuinely fires rather than the assertion passing by accident.

Verified locally:

- `pre-commit run --all-files` — regenerated `charts/infra/README.md`; committed, re-run clean
- `helm lint charts/infra/ charts/app/` — 2 linted, 0 failed
- `helm unittest --strict charts/infra/ charts/app/` — 36 suites, 265 tests, all passed
- real `helm template` runs confirming retention renders `90` by default, `30` when overridden, and that the guard still fires

Refs PLAT-626, portswigger-it/platform#821. See also BAE-1538 (Object Lock, will reuse the guard helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)