### PR TITLE
feat(cron): ttlSecondsAfterFinished passthrough, bump to 0.5.0 (BAE-2935)

### DIFF
--- a/charts/cron/Chart.yaml
+++ b/charts/cron/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying cron jobs
 
 type: application
 
-version: 0.4.10
+version: 0.5.0
 
-appVersion: 0.4.10
+appVersion: 0.5.0
 
 keywords:
   - cron

--- a/charts/cron/README.md
+++ b/charts/cron/README.md
@@ -1,6 +1,6 @@
 # cron
 
-![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.10](https://img.shields.io/badge/AppVersion-0.4.10-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 A Helm "monochart" for deploying cron jobs
 
@@ -54,6 +54,7 @@ helm install cron helm-charts/cron
 | cron.parallelism | int | `1` | Number of pods of the cron job to start |
 | cron.restartPolicy | string | `"Never"` | Whether or not the pod should restart on failure. Valid values are: `Never` or `onFailure` |
 | cron.timeoutSeconds | int | `86400` | The maximum amount of time the job should run for in seconds. |
+| cron.ttlSecondsAfterFinished | string | unset, i.e. Kubernetes' default retention | Seconds to keep a finished `Job`, and its pods, before the TTL controller deletes them. This applies to FAILED Jobs too, which is the reason to set it: a failed run's pods are otherwise retained until the Job is rotated out by `failedJobsHistoryLimit`, so a "pod not running" alert watching them never clears and one broken run pages forever rather than once. Pick a window long enough to read the logs in. Left unset, retention is unchanged from Kubernetes' default. `0` is not expressible here (it reads as unset); the smallest deleting value is `1`. |
 
 ### infra
 

--- a/charts/cron/templates/kubernetes/cronjob.yaml
+++ b/charts/cron/templates/kubernetes/cronjob.yaml
@@ -13,4 +13,7 @@ spec:
       activeDeadlineSeconds: {{ .Values.cron.timeoutSeconds }}
       parallelism: {{ .Values.cron.parallelism }}
       backoffLimit: {{ .Values.cron.retries }}
+      {{- if .Values.cron.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.cron.ttlSecondsAfterFinished }}
+      {{- end }}
       template: {{ template "cron.podTemplate" . }}

--- a/charts/cron/tests/cronjob_test.yaml
+++ b/charts/cron/tests/cronjob_test.yaml
@@ -294,3 +294,17 @@ tests:
               secretKeyRef:
                 name: override-opensearch
                 key: id
+
+  - it: should not set a job TTL by default
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished
+
+  - it: should set the job TTL when one is given
+    set:
+      cron:
+        ttlSecondsAfterFinished: 3600
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished
+          value: 3600

--- a/charts/cron/values.yaml
+++ b/charts/cron/values.yaml
@@ -70,6 +70,17 @@ cron:
   # @section -- cron
   timeoutSeconds: 86400
 
+  # cron.ttlSecondsAfterFinished -- Seconds to keep a finished `Job`, and its pods, before the
+  # TTL controller deletes them. This applies to FAILED Jobs too, which is the reason to set it:
+  # a failed run's pods are otherwise retained until the Job is rotated out by
+  # `failedJobsHistoryLimit`, so a "pod not running" alert watching them never clears and one
+  # broken run pages forever rather than once. Pick a window long enough to read the logs in.
+  # Left unset, retention is unchanged from Kubernetes' default. `0` is not expressible here
+  # (it reads as unset); the smallest deleting value is `1`.
+  # @default -- unset, i.e. Kubernetes' default retention
+  # @section -- cron
+  ttlSecondsAfterFinished:
+
 # env -- **Non-secret** environment variables to configure your application. Formatted as `ENV_VAR_NAME: env-var-value`
 # @section -- application
 env: {}


### PR DESCRIPTION
Adds a `cron.ttlSecondsAfterFinished` passthrough to the `cron` chart. **No behaviour change for any existing consumer** — the field renders only when the value is set, so every release that does not set it keeps exactly the retention it has today.

## Why

The chart currently gives no way to express a TTL on a finished Job, and the gap has a sharp edge. A failed run's pods are retained until `failedJobsHistoryLimit` rotates the Job out, so an alert watching for non-running pods never clears: **one broken run pages on every evaluation instead of once.**

That is not hypothetical. It took the `hakawai-knowledge-skills` publisher offline in prod on 2026-08-12 — each failure left two Error pods (`backoffLimit: 1`), nothing ever collected them, and "pod not running > 5 min" fired `severity: critical` hourly for a fault that had already been fixed. The CronJob had to be suspended by hand to stop the noise, and it cannot safely be re-enabled until this exists (BAE-2935).

## The change

```yaml
      backoffLimit: {{ .Values.cron.retries }}
      {{- if .Values.cron.ttlSecondsAfterFinished }}
      ttlSecondsAfterFinished: {{ .Values.cron.ttlSecondsAfterFinished }}
      {{- end }}
```

- `charts/cron/values.yaml` — new key, unset by default, documented including what to pick and why
- `charts/cron/tests/cronjob_test.yaml` — two cases: absent by default, present when given
- `charts/cron/Chart.yaml` — 0.4.10 -> 0.5.0 (`version` and `appVersion`), without which chart-releaser silently publishes nothing
- `charts/cron/README.md` — regenerated with the repo's exact invocation, never hand-edited:
  `helm-docs --chart-search-root=charts --template-files=./README.md.gotmpl --sort-values-order=file`

## One deliberate limitation

`0` is not expressible — it reads as unset under the `{{- if }}` idiom, matching `deployment.averageMemoryUtilization` in the `app` chart. Documented in `values.yaml` rather than worked around, because an immediate-delete TTL throws away the logs of the very failure it is cleaning up. The smallest deleting value is `1`.

## Verification

`helm template` both ways — absent by default, and present as `spec.jobTemplate.spec.ttlSecondsAfterFinished` when given. `helm lint` clean.

`helm unittest` could not be run locally: the plugin binary is killed on this machine (exit 137), unrelated to this change. CI runs the suite on this PR, so the two new cases are covered there.

BAE-2935.
