### PR TITLE
feat(app): expose Deployment rolling-update pacing (maxSurge / maxUnavailable)

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm "monochart" for deploying common application patterns
 
 type: application
 
-version: 0.50.1
+version: 0.51.0
 
-appVersion: 0.50.1
+appVersion: 0.51.0
 
 keywords:
   - app

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.50.1](https://img.shields.io/badge/Version-0.50.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.50.1](https://img.shields.io/badge/AppVersion-0.50.1-informational?style=flat-square)
+![Version: 0.51.0](https://img.shields.io/badge/Version-0.51.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.51.0](https://img.shields.io/badge/AppVersion-0.51.0-informational?style=flat-square)
 
 A Helm "monochart" for deploying common application patterns
 
@@ -58,6 +58,8 @@ helm install app helm-charts/app
 | deployment.averageCpuUtilization | int | `9` | The target average CPU utilization percentage for the HorizontalPodAutoscaler |
 | deployment.averageMemoryUtilization | int | `disabled` | The target average Memory utilization percentage for the HorizontalPodAutoscaler |
 | deployment.customAutoscalingMetrics | list | `disabled` | Advanced: A list of custom metrics scalers. |
+| deployment.rollingUpdate.maxSurge | string | `"50%"` | Maximum extra pods (absolute integer or percentage) the rolling update may create above `deployment.replicas`. `"100%"` starts a full replacement set before any old pod is terminated. |
+| deployment.rollingUpdate.maxUnavailable | string | `"25%"` | Maximum pods (absolute integer or percentage) that may be unavailable during a rolling update. `0` guarantees the old pods keep serving until their replacements are Ready; combined with `maxSurge: "100%"` the old pods then all begin their graceful drain together. |
 | deployment.terminationGracePeriodSeconds | int | `30 + terminationDelay.delaySeconds` | Explicit pod terminationGracePeriodSeconds. When set, it overrides the value derived from `terminationDelay` — use it to give a workload a long graceful-drain window without inflating the preStop sleep. Leave unset to keep the historical `30 + terminationDelay.delaySeconds` behaviour. |
 | pdb.maxUnavailable | string | `"50%"` | Maximum pods that may be voluntarily disrupted at one time. Absolute integer (e.g. `1`) or percentage (e.g. `"50%"`). Only applied when `deployment.replicas > 1`. Mutually exclusive with `pdb.minAvailable`. |
 | pdb.minAvailable | string | `nil` | Minimum pods that must remain available. When set, takes precedence over `maxUnavailable`. Absolute integer or percentage. |

--- a/charts/app/templates/kubernetes/deployment.yaml
+++ b/charts/app/templates/kubernetes/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 50%
-      maxUnavailable: 25%
+      maxSurge: {{ .Values.deployment.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.deployment.rollingUpdate.maxUnavailable }}
   minReadySeconds: 5
   template: {{ template "app.podTemplate" . }}

--- a/charts/app/tests/kubernetes_deployment_test.yaml
+++ b/charts/app/tests/kubernetes_deployment_test.yaml
@@ -1040,3 +1040,29 @@ tests:
           content:
             name: NATS_URL
             value: nats://nats-server.events.svc.cluster.local:4223
+  - it: should keep the historical rolling-update pacing by default
+    template: kubernetes/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.strategy
+          value:
+            type: RollingUpdate
+            rollingUpdate:
+              maxSurge: 50%
+              maxUnavailable: 25%
+
+  - it: should render configured rolling-update pacing
+    template: kubernetes/deployment.yaml
+    set:
+      deployment:
+        rollingUpdate:
+          maxSurge: 100%
+          maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.strategy
+          value:
+            type: RollingUpdate
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 0

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -130,6 +130,18 @@ deployment:
   #     target:
   #       type: AverageValue
   #       averageValue: "160"
+  rollingUpdate:
+    # deployment.rollingUpdate.maxSurge -- Maximum extra pods (absolute integer or
+    # percentage) the rolling update may create above `deployment.replicas`. `"100%"`
+    # starts a full replacement set before any old pod is terminated.
+    # @section -- application
+    maxSurge: "50%"
+    # deployment.rollingUpdate.maxUnavailable -- Maximum pods (absolute integer or
+    # percentage) that may be unavailable during a rolling update. `0` guarantees the
+    # old pods keep serving until their replacements are Ready; combined with
+    # `maxSurge: "100%"` the old pods then all begin their graceful drain together.
+    # @section -- application
+    maxUnavailable: "25%"
   # deployment.terminationGracePeriodSeconds -- (int) Explicit pod terminationGracePeriodSeconds.
   # When set, it overrides the value derived from `terminationDelay` — use it to give a workload
   # a long graceful-drain window without inflating the preStop sleep. Leave unset to keep the


### PR DESCRIPTION
## Summary

BAE-2962. The app chart hardcodes the Deployment rolling-update strategy at `maxSurge: 50%` / `maxUnavailable: 25%`. This exposes both as `deployment.rollingUpdate.*` values with those exact defaults - **no existing consumer changes behaviour** (unit test pins the default render).

## Why

hakawai-mcp-gateway holds a long-lived reverse-SSE connection from every Burp Desktop. With the hardcoded pacing, a deploy kills the old pods at different times spread over ~2.5 minutes, so Desktops reconnect onto old pods that then die on them and their tool-list requests die with the sending pod (BAE-2944 - ~289 accounts lost Burp tools across two deploys on 2026-08-13; full analysis in hakawai-wiki ADR-0101). Setting `maxSurge: 100%` / `maxUnavailable: 0` starts a full replacement set before any old pod terminates, so all old pods begin their graceful drain together and every Desktop disconnects exactly once.

## Changes

- `values.yaml`: `deployment.rollingUpdate.maxSurge` (default "50%") and `deployment.rollingUpdate.maxUnavailable` (default "25%"), helm-docs comments included
- `templates/kubernetes/deployment.yaml`: render `spec.strategy.rollingUpdate` from the values; strategy type stays RollingUpdate
- Tests: default render pinned to today's 50%/25%; override render (100%/0) asserted
- Chart 0.50.1 -> 0.51.0 so chart-releaser publishes; READMEs regenerated with the pinned helm-docs invocation

## Validation

- `helm lint charts/app/` clean
- `helm unittest --strict` (via helmunittest/helm-unittest docker image): 22 suites, 169 tests, all pass
- helm-docs run with the exact .pre-commit-config.yaml flags (chart-search-root/template-files/sort-values-order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)